### PR TITLE
feat: Update sample app to SDK 2.1.2 with enhanced configuration

### DIFF
--- a/sampleSwift/sampleSwift.xcodeproj/project.pbxproj
+++ b/sampleSwift/sampleSwift.xcodeproj/project.pbxproj
@@ -476,7 +476,7 @@
 			repositoryURL = "https://github.com/axeptio/axeptio-ios-sdk";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 2.0.16;
+				minimumVersion = 2.1.2;
 			};
 		};
 		C2AAF8D02B85F42A00447D7B /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {

--- a/sampleSwift/sampleSwift.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/sampleSwift/sampleSwift.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/axeptio/axeptio-ios-sdk",
       "state" : {
-        "revision" : "379d6cb56afa6914693c6df3ee5e96d16fd8a450",
-        "version" : "2.0.16"
+        "revision" : "649e9b0d7d20aa54df50baa92f7d54cba1fcac0d",
+        "version" : "2.1.2"
       }
     },
     {

--- a/sampleSwift/sampleSwift/AppDelegate.swift
+++ b/sampleSwift/sampleSwift/AppDelegate.swift
@@ -28,21 +28,17 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         
         // Initialize Axeptio with dynamic configuration
         let config = ConfigurationManager.shared.currentConfiguration
-        
-        if let token = config.token {
-            Axeptio.shared.initialize(
-                targetService: config.targetService,
-                clientId: config.clientId,
-                cookiesVersion: config.cookiesVersion,
-                token: token
-            )
-        } else {
-            Axeptio.shared.initialize(
-                targetService: config.targetService,
-                clientId: config.clientId,
-                cookiesVersion: config.cookiesVersion
-            )
-        }
+
+        Axeptio.shared.initialize(
+            targetService: config.targetService,
+            clientId: config.clientId,
+            cookiesVersion: config.cookiesVersion,
+            token: config.token,
+            widgetType: config.widgetType,
+            widgetPR: config.widgetPR,
+            cookiesDurationDays: config.cookiesDuration,
+            shouldUpdateCookiesDuration: config.shouldUpdateCookiesDuration
+        )
 
         // Configure ATT popup behavior
         Axeptio.shared.allowPopupDisplayWithRejectedDeviceTrackingPermissions(config.allowPopupWithRejectedATT)

--- a/sampleSwift/sampleSwift/ConfigurationManager.swift
+++ b/sampleSwift/sampleSwift/ConfigurationManager.swift
@@ -16,6 +16,10 @@ struct CustomerConfiguration {
     let clientId: String
     let cookiesVersion: String
     let token: String?
+    let cookiesDuration: Int
+    let shouldUpdateCookiesDuration: Bool
+    let widgetType: WidgetType
+    let widgetPR: String?
     let targetService: AxeptioService
     let allowPopupWithRejectedATT: Bool
 
@@ -26,25 +30,33 @@ struct CustomerConfiguration {
 
 class ConfigurationManager {
     static let shared = ConfigurationManager()
-    
+
     private let userDefaults = UserDefaults.standard
-    
+
     // UserDefaults keys
     private enum Keys {
         static let clientId = "axeptio.config.clientId"
         static let cookiesVersion = "axeptio.config.cookiesVersion"
         static let token = "axeptio.config.token"
+        static let cookiesDuration = "axeptio.config.duration"
+        static let shouldUpdateCookiesDuration = "axeptio.config.cookiesDurationUpdate"
+        static let widgetType = "axeptio.config.widgetType"
+        static let widgetPR = "axeptio.config.widgetPR"
         static let targetService = "axeptio.config.targetService"
         static let allowPopupWithRejectedATT = "axeptio.config.allowPopupWithRejectedATT"
         static let hasCustomConfiguration = "axeptio.config.hasCustom"
     }
-    
+
     // Default configurations for quick testing
     static let presetConfigurations: [String: CustomerConfiguration] = [
         "Default Brands": CustomerConfiguration(
             clientId: "5fbfa806a0787d3985c6ee5f",
             cookiesVersion: "insideapp-brands",
             token: "5sj42u50ta2ys8c3nhjkxi",
+            cookiesDuration: 190,
+            shouldUpdateCookiesDuration: false,
+            widgetType: .production,
+            widgetPR: nil,
             targetService: .brands,
             allowPopupWithRejectedATT: false
         ),
@@ -52,6 +64,10 @@ class ConfigurationManager {
             clientId: "5fbfa806a0787d3985c6ee5f",
             cookiesVersion: "google cmp partner program sandbox-en-EU",
             token: "5sj42u50ta2ys8c3nhjkxi",
+            cookiesDuration: 190,
+            shouldUpdateCookiesDuration: false,
+            widgetType: .production,
+            widgetPR: nil,
             targetService: .publisherTcf,
             allowPopupWithRejectedATT: false
         ),
@@ -59,6 +75,10 @@ class ConfigurationManager {
             clientId: "5fbfa806a0787d3985c6ee5f",
             cookiesVersion: "insideapp-brands",
             token: nil,
+            cookiesDuration: 190,
+            shouldUpdateCookiesDuration: false,
+            widgetType: .production,
+            widgetPR: nil,
             targetService: .brands,
             allowPopupWithRejectedATT: false
         ),
@@ -66,6 +86,10 @@ class ConfigurationManager {
             clientId: "5fbfa806a0787d3985c6ee5f",
             cookiesVersion: "google cmp partner program sandbox-en-EU",
             token: nil,
+            cookiesDuration: 190,
+            shouldUpdateCookiesDuration: false,
+            widgetType: .production,
+            widgetPR: nil,
             targetService: .publisherTcf,
             allowPopupWithRejectedATT: false
         ),
@@ -73,6 +97,10 @@ class ConfigurationManager {
             clientId: "5fbfa806a0787d3985c6ee5f",
             cookiesVersion: "insideapp-brands",
             token: "5sj42u50ta2ys8c3nhjkxi",
+            cookiesDuration: 190,
+            shouldUpdateCookiesDuration: false,
+            widgetType: .production,
+            widgetPR: nil,
             targetService: .brands,
             allowPopupWithRejectedATT: true
         ),
@@ -80,20 +108,28 @@ class ConfigurationManager {
             clientId: "5fbfa806a0787d3985c6ee5f",
             cookiesVersion: "google cmp partner program sandbox-en-EU",
             token: "5sj42u50ta2ys8c3nhjkxi",
+            cookiesDuration: 190,
+            shouldUpdateCookiesDuration: false,
+            widgetType: .production,
+            widgetPR: nil,
             targetService: .publisherTcf,
             allowPopupWithRejectedATT: true
         )
     ]
-    
+
     private init() {}
-    
+
     // MARK: - Current Configuration
-    
+
     var currentConfiguration: CustomerConfiguration {
         get {
             let clientId = userDefaults.string(forKey: Keys.clientId) ?? "5fbfa806a0787d3985c6ee5f"
             let cookiesVersion = userDefaults.string(forKey: Keys.cookiesVersion) ?? "insideapp-brands"
             let token = userDefaults.string(forKey: Keys.token)
+            let cookiesDuration = userDefaults.object(forKey: Keys.cookiesDuration) as? Int ?? 190
+            let shouldUpdateCookiesDuration = userDefaults.bool(forKey: Keys.shouldUpdateCookiesDuration)
+            let widgetType = WidgetType(rawValue: userDefaults.integer(forKey: Keys.widgetType))
+            let widgetPR = userDefaults.string(forKey: Keys.widgetPR)
             let serviceRawValue = userDefaults.integer(forKey: Keys.targetService)
             let targetService: AxeptioService = serviceRawValue == 1 ? .publisherTcf : .brands
             let allowPopupWithRejectedATT = userDefaults.bool(forKey: Keys.allowPopupWithRejectedATT)
@@ -102,6 +138,10 @@ class ConfigurationManager {
                 clientId: clientId,
                 cookiesVersion: cookiesVersion,
                 token: token?.isEmpty == false ? token : nil,
+                cookiesDuration: cookiesDuration,
+                shouldUpdateCookiesDuration: shouldUpdateCookiesDuration,
+                widgetType: widgetType ?? .production,
+                widgetPR: widgetPR?.isEmpty == false ? widgetPR : nil,
                 targetService: targetService,
                 allowPopupWithRejectedATT: allowPopupWithRejectedATT
             )
@@ -110,67 +150,80 @@ class ConfigurationManager {
             userDefaults.set(newValue.clientId, forKey: Keys.clientId)
             userDefaults.set(newValue.cookiesVersion, forKey: Keys.cookiesVersion)
             userDefaults.set(newValue.token, forKey: Keys.token)
+            userDefaults.set(newValue.cookiesDuration, forKey: Keys.cookiesDuration)
+            userDefaults.set(newValue.shouldUpdateCookiesDuration, forKey: Keys.shouldUpdateCookiesDuration)
+            userDefaults.set(newValue.widgetType.rawValue, forKey: Keys.widgetType)
+            userDefaults.set(newValue.widgetPR, forKey: Keys.widgetPR)
             userDefaults.set(newValue.targetService == .publisherTcf ? 1 : 0, forKey: Keys.targetService)
             userDefaults.set(newValue.allowPopupWithRejectedATT, forKey: Keys.allowPopupWithRejectedATT)
             userDefaults.set(true, forKey: Keys.hasCustomConfiguration)
         }
     }
-    
+
     var hasCustomConfiguration: Bool {
         return userDefaults.bool(forKey: Keys.hasCustomConfiguration)
     }
-    
+
     // MARK: - Configuration Management
-    
+
     func loadPresetConfiguration(_ presetName: String) {
         guard let config = Self.presetConfigurations[presetName] else { return }
         currentConfiguration = config
     }
-    
+
     func resetToDefault() {
         userDefaults.removeObject(forKey: Keys.clientId)
         userDefaults.removeObject(forKey: Keys.cookiesVersion)
         userDefaults.removeObject(forKey: Keys.token)
+        userDefaults.removeObject(forKey: Keys.cookiesDuration)
+        userDefaults.removeObject(forKey: Keys.shouldUpdateCookiesDuration)
+        userDefaults.removeObject(forKey: Keys.widgetType)
+        userDefaults.removeObject(forKey: Keys.widgetPR)
         userDefaults.removeObject(forKey: Keys.targetService)
         userDefaults.removeObject(forKey: Keys.allowPopupWithRejectedATT)
         userDefaults.removeObject(forKey: Keys.hasCustomConfiguration)
     }
-    
+
     // MARK: - Validation
-    
+
     func validateConfiguration(_ config: CustomerConfiguration) -> [String] {
         var errors: [String] = []
-        
+
         if config.clientId.isEmpty {
             errors.append("Client ID is required")
         } else if config.clientId.count < 10 {
             errors.append("Client ID appears to be too short")
         }
-        
+
         if config.cookiesVersion.isEmpty {
             errors.append("Cookies Version is required")
         }
-        
+
         // Token validation is optional
         if let token = config.token, !token.isEmpty && token.count < 10 {
             errors.append("Token appears to be too short")
         }
-        
+
+        // Widget PR Validation is also optional
+        if let widgetVerison = config.widgetPR, !widgetVerison.isEmpty && widgetVerison.count < 5 {
+            errors.append("Widget Version appears to be too short")
+        }
+
         return errors
     }
-    
+
     // MARK: - Display Helpers
-    
+
     var currentServiceDisplayName: String {
         return currentConfiguration.targetService == .brands ? "Brands" : "Publisher TCF"
     }
-    
+
     var currentServiceColor: String {
         return currentConfiguration.targetService == .brands ? "AxeptioYellow" : "AxeptioBlueLight"
     }
-    
+
     // MARK: - WebView URLs
-    
+
     func getWebViewURL() -> String {
         switch currentConfiguration.targetService {
         case .brands:

--- a/sampleSwift/sampleSwift/View/ConfigurationViewController.swift
+++ b/sampleSwift/sampleSwift/View/ConfigurationViewController.swift
@@ -509,10 +509,12 @@ extension ConfigurationViewController: UITableViewDataSource, UITableViewDelegat
         cookiesDurationSwitch.isOn = config.shouldUpdateCookiesDuration
         cookiesDurationTextfield.text = config.shouldUpdateCookiesDuration ? String(config.cookiesDuration) : ""
         widgetPRTextField.text = config.widgetPR ?? ""
+        widgetTypeSegmentedControl.selectedSegmentIndex = config.widgetType.rawValue
         serviceSegmentedControl.selectedSegmentIndex = config.targetService == .brands ? 0 : 1
         allowPopupSwitch.isOn = config.allowPopupWithRejectedATT
 
         hasUnsavedChanges = true
+        updateOptionalFieldsVisbility()
         updateSaveButtonState()
     }
 

--- a/sampleSwift/sampleSwift/View/ViewController.swift
+++ b/sampleSwift/sampleSwift/View/ViewController.swift
@@ -110,7 +110,7 @@ class ViewController: UIViewController {
         sdkVersionLabel.textAlignment = .center
         sdkVersionLabel.numberOfLines = 0
         sdkVersionLabel.textColor = .tertiaryLabel
-        sdkVersionLabel.text = "Axeptio iOS SDK v2.0.15"
+        sdkVersionLabel.text = "Axeptio iOS SDK v2.1.2"
     }
 
     
@@ -427,8 +427,10 @@ class ViewController: UIViewController {
     }
     
     @IBAction func showSettings(_ sender: Any) {
+        let remainingDays = Axeptio.shared.getRemainingDaysForConsent()
         let configViewController = ConfigurationViewController()
         configViewController.delegate = self
+        configViewController.remainingDays = remainingDays
         let navController = UINavigationController(rootViewController: configViewController)
         self.present(navController, animated: true)
     }


### PR DESCRIPTION
## Summary

This PR updates the public sample-app-ios repository from SDK version 2.0.16 to 2.1.2, bringing it in sync with the private repo's enhanced configuration features and demonstrating all new SDK capabilities.

**Linear:** MSK-137

## What Changed

### SDK Version Update
- Updated from SDK 2.0.16 (September 2025) to 2.1.2 (December 2025)
- Updated SPM dependency in project.pbxproj

### ConfigurationManager Enhancements
- Added cookie duration management:
  - `cookiesDuration` property (default: 190 days)
  - `shouldUpdateCookiesDuration` flag
- Added widget environment selection:
  - `widgetType` property (production/staging/PR)
  - `widgetPR` property for PR version testing
- Fixed MSK-136 bug: Changed from `userDefaults.integer(forKey:)` to `userDefaults.object(forKey:) as? Int ?? 190` to provide correct default value
- Updated all preset configurations with new parameters

### SDK Initialization Update
- Updated AppDelegate.swift to pass all new SDK parameters:
  - `widgetType`
  - `widgetPR`
  - `cookiesDurationDays`
  - `shouldUpdateCookiesDuration`

### Configuration UI Enhancements
- Added cookie duration controls:
  - Toggle switch for shouldUpdateCookiesDuration
  - Text field for custom duration
  - Remaining days display
- Added widget type segmented control (Production/Staging/PR)
- Added widget PR text field (shown only when PR type selected)
- Added dynamic field visibility based on configuration
- Updated ViewController to pass `remainingDays` to ConfigurationViewController

### Version Label
- Updated SDK version label from "v2.0.15" to "v2.1.2" in ViewController

## Bug Fixes

### MSK-136: Consent Duration Persistence
The sample app's ConfigurationManager had the same bug that was fixed in SDK 2.1.2 - using `userDefaults.integer(forKey:)` which returns 0 when the key doesn't exist, causing consent to expire immediately. Now uses `userDefaults.object(forKey:) as? Int ?? 190` for proper default value.

## Testing

- ✅ Build succeeds on iOS Simulator (iPhone 16, iOS 18.4)
- ✅ All files compile without errors or warnings
- ✅ Configuration UI includes all new features
- ✅ SDK initialization includes all new parameters

## Related

- Linear: MSK-137
- SDK version: 2.1.2
- Private repo: axeptio-ios-sdk-sources (already at 2.1.2)
- Related SDK issue: MSK-136 (consent persistence fix)
- Related SDK PRs: #73, #74

## Migration Notes

This is a feature update that adds new configuration options to the sample app. No breaking changes. The sample app now demonstrates:
- Widget environment selection (production/staging/PR)
- Cookie duration management
- PR version testing
- Consent expiration display

The app will work identically for users who don't change the new default settings.