### PR TITLE
fix: address Copilot PR review comments

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,9 +26,9 @@
     "pre-commit": "npm run lint:check && npm run build:check && npm run test:check",
     "lint": "swiftlint --strict",
     "lint:check": "command -v swiftlint >/dev/null 2>&1 && npm run lint || echo 'SwiftLint not found, skipping lint check'",
-    "build": "xcodebuild -workspace sampleSwift/sampleSwift.xcodeproj/project.xcworkspace -scheme sampleSwift -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.6' build",
+    "build": "xcodebuild -workspace sampleSwift/sampleSwift.xcodeproj/project.xcworkspace -scheme sampleSwift -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' build",
     "build:check": "command -v xcodebuild >/dev/null 2>&1 && npm run build || echo 'Xcode not found, skipping build check'",
-    "test": "xcodebuild -workspace sampleSwift/sampleSwift.xcodeproj/project.xcworkspace -scheme sampleSwift -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.6' test",
+    "test": "xcodebuild -workspace sampleSwift/sampleSwift.xcodeproj/project.xcworkspace -scheme sampleSwift -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' test",
     "test:check": "command -v xcodebuild >/dev/null 2>&1 && npm run test || echo 'Xcode not found, skipping test check'",
     "prepare": "husky"
   },

--- a/sampleSwift/sampleSwift/View/ConfigurationViewController.swift
+++ b/sampleSwift/sampleSwift/View/ConfigurationViewController.swift
@@ -38,6 +38,7 @@ class ConfigurationViewController: UIViewController {
     private let presetConfigurations = Array(ConfigurationManager.presetConfigurations.keys).sorted()
 
     private var hasUnsavedChanges = false
+    private var editingForceShowConsent: Bool = false
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -342,6 +343,7 @@ class ConfigurationViewController: UIViewController {
         serviceSegmentedControl.selectedSegmentIndex = config.targetService == .brands ? 0 : 1
         widgetTypeSegmentedControl.selectedSegmentIndex = config.widgetType.rawValue
         allowPopupSwitch.isOn = config.allowPopupWithRejectedATT
+        editingForceShowConsent = config.forceShowConsent
 
         hasUnsavedChanges = false
         updateSaveButtonState()
@@ -409,7 +411,7 @@ class ConfigurationViewController: UIViewController {
             widgetPR: widgetPRTextField.text?.trimmingCharacters(in: .whitespacesAndNewlines),
             targetService: serviceSegmentedControl.selectedSegmentIndex == 0 ? .brands : .publisherTcf,
             allowPopupWithRejectedATT: allowPopupSwitch.isOn,
-            forceShowConsent: ConfigurationManager.shared.currentConfiguration.forceShowConsent
+            forceShowConsent: editingForceShowConsent
         )
 
         // Basic validation
@@ -513,6 +515,7 @@ extension ConfigurationViewController: UITableViewDataSource, UITableViewDelegat
         widgetTypeSegmentedControl.selectedSegmentIndex = config.widgetType.rawValue
         serviceSegmentedControl.selectedSegmentIndex = config.targetService == .brands ? 0 : 1
         allowPopupSwitch.isOn = config.allowPopupWithRejectedATT
+        editingForceShowConsent = config.forceShowConsent
 
         hasUnsavedChanges = true
         updateOptionalFieldsVisbility()

--- a/sampleSwift/sampleSwift/View/ConfigurationViewController.swift
+++ b/sampleSwift/sampleSwift/View/ConfigurationViewController.swift
@@ -409,7 +409,7 @@ class ConfigurationViewController: UIViewController {
             widgetPR: widgetPRTextField.text?.trimmingCharacters(in: .whitespacesAndNewlines),
             targetService: serviceSegmentedControl.selectedSegmentIndex == 0 ? .brands : .publisherTcf,
             allowPopupWithRejectedATT: allowPopupSwitch.isOn,
-            forceShowConsent: false
+            forceShowConsent: ConfigurationManager.shared.currentConfiguration.forceShowConsent
         )
 
         // Basic validation


### PR DESCRIPTION
## Summary

- Preserve `forceShowConsent` from persisted config in `saveTapped()` instead of hardcoding `false` — prevents silently overwriting preset or stored values
- Replace pinned `OS=18.6` with `OS=latest` in `package.json` `build` and `test` scripts — fixes builds for contributors/CI with different iOS 18.x runtimes

## Test plan

- [ ] Verify `forceShowConsent` value is preserved when saving configuration (no regression on existing presets)
- [ ] Verify `npm run build:check` passes locally with `OS=latest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)