### PR TITLE
chore: add PR title validation workflow [ENG-11179]

### DIFF
--- a/.github/workflows/validate-pull-request-title.yml
+++ b/.github/workflows/validate-pull-request-title.yml
@@ -1,0 +1,13 @@
+name: Validate PR Title
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened, ready_for_review]
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  validate:
+    uses: axeptio/tech-scripts/.github/workflows/validate-pull-request-title.yml@validate-pull-request-title-v1.0.0


### PR DESCRIPTION
## Summary
- Adds the standard `validate-pull-request-title` reusable workflow
- Required to satisfy ENG-11179 compliance: ≥1 Required Status Check on the protected default branch

## Test plan
- [ ] Workflow runs on this PR and the check `Validate PR Title / validate` appears
- [ ] After merge, register the check as required on `master` branch protection

🤖 Generated with [Claude Code](https://claude.com/claude-code)