### PR TITLE
feat: add sampleSwiftUITests UI test suite + inline CI

### DIFF
--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -43,7 +43,9 @@ jobs:
             -scheme sampleSwift \
             -destination 'platform=iOS Simulator,name=iPhone 16' \
             -resultBundlePath TestResults.xcresult \
-            -only-testing:sampleSwiftUITests
+            -only-testing:sampleSwiftUITests \
+            -retry-tests-on-failure \
+            -test-iterations 3
 
       - name: Upload test results
         if: always()

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -1,0 +1,52 @@
+name: UI Tests
+
+# Runs the sampleSwiftUITests XCUITest suite against the sampleSwift app.
+# Kept fully inline (no reusable workflow): this repo is public and cannot call
+# Axeptio's internal/private reusable workflows.
+
+on:
+  pull_request:
+    branches: [develop, master]
+    types: [opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
+
+concurrency:
+  group: ui-tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ui-tests:
+    name: XCUITest (iPhone 16)
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+
+      - name: Resolve Swift packages
+        working-directory: sampleSwift
+        run: xcodebuild -resolvePackageDependencies -project sampleSwift.xcodeproj -scheme sampleSwift
+
+      - name: Run UI tests
+        working-directory: sampleSwift
+        run: |
+          xcodebuild test \
+            -project sampleSwift.xcodeproj \
+            -scheme sampleSwift \
+            -destination 'platform=iOS Simulator,name=iPhone 16' \
+            -resultBundlePath TestResults.xcresult \
+            -only-testing:sampleSwiftUITests
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ui-test-results
+          path: sampleSwift/TestResults.xcresult
+          if-no-files-found: ignore
+          retention-days: 7

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -1,13 +1,15 @@
 name: UI Tests
 
 # Runs the sampleSwiftUITests XCUITest suite against the sampleSwift app.
+# Runs nightly (and on manual dispatch), not as a PR gate: the suite drives the
+# live Axeptio consent webview over the network and takes ~30 min, which is too
+# slow/flaky to block PRs.
 # Kept fully inline (no reusable workflow): this repo is public and cannot call
 # Axeptio's internal/private reusable workflows.
 
 on:
-  pull_request:
-    branches: [develop, master]
-    types: [opened, synchronize, reopened, ready_for_review]
+  schedule:
+    - cron: '0 3 * * *' # nightly at 03:00 UTC, on the default branch
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -10,6 +10,9 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ui-tests-${{ github.ref }}
   cancel-in-progress: true

--- a/.gitignore
+++ b/.gitignore
@@ -206,3 +206,10 @@ dist
 
 # TernJS port file
 .tern-port
+# Code signing material — never commit to this public repo
+*.p12
+*.cer
+*.pem
+*.key
+*.certSigningRequest
+*.mobileprovision

--- a/sampleSwift/sampleSwift.xcodeproj/project.pbxproj
+++ b/sampleSwift/sampleSwift.xcodeproj/project.pbxproj
@@ -7,10 +7,18 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		20418CC8FF6A336BFA7EDD34 /* Test2_ConsentFlowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ECC2AC04396067BC238F21B /* Test2_ConsentFlowTests.swift */; };
+		2D3DBF3EB8979EFF061D10B2 /* sampleSwiftUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 550778A01D2C1E74652633FB /* sampleSwiftUITests.swift */; };
+		2F5E764B8C7FB4D6853EFB02 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F44A27F34A1D1E5198AFA0F4 /* Foundation.framework */; };
+		44F2AE902CE87B661427D9C9 /* Test1_WidgetDisplayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDD2FE39A92DB28C1FBD05EA /* Test1_WidgetDisplayTests.swift */; };
 		4D2D1AE42BE871C800C114EC /* WebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D2D1AE32BE871C800C114EC /* WebViewController.swift */; };
 		5C0AD4A62E6060FD0018022E /* ConfigurationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C0AD4A42E6060FD0018022E /* ConfigurationViewController.swift */; };
 		5C0AD4A72E6060FD0018022E /* VendorConsentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C0AD4A52E6060FD0018022E /* VendorConsentViewController.swift */; };
 		5C3009D72E60F32B002D98CA /* ConfigurationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C3009D62E60F32B002D98CA /* ConfigurationManager.swift */; };
+		6413B8311E7846405DE58C7F /* AxeptioIntegrationTestsHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = D01A4E45CCDEE08C898B7393 /* AxeptioIntegrationTestsHelper.swift */; };
+		69319B09ACBA85ECA9B67CE6 /* Test0_DiagnosticTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F9F52BFC93E9D1FD0C86D49 /* Test0_DiagnosticTest.swift */; };
+		931FCBC4DDB8DB500F15FB43 /* sampleSwiftUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96402763F6C1351AFFBA1C9A /* sampleSwiftUITestsLaunchTests.swift */; };
+		959DE2ECF071305834FA50D5 /* Test3_PersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2AE64F7CB52569AE78E490E /* Test3_PersistenceTests.swift */; };
 		B139B2032CAEEBD900F8C284 /* CookieFields.swift in Sources */ = {isa = PBXBuildFile; fileRef = B139B2022CAEEBD900F8C284 /* CookieFields.swift */; };
 		B1DA856D2CB7B354005A9437 /* AxeptioSDK in Frameworks */ = {isa = PBXBuildFile; productRef = B1DA856C2CB7B354005A9437 /* AxeptioSDK */; };
 		B3AA94F62E43D7B700457A2C /* ConsentDebugViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3AA94F52E43D7B700457A2C /* ConsentDebugViewController.swift */; };
@@ -25,7 +33,18 @@
 		C2F130FA2B750EF80079B2DF /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C2F130F82B750EF80079B2DF /* Main.storyboard */; };
 		C2F130FC2B750EFC0079B2DF /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C2F130FB2B750EFC0079B2DF /* Assets.xcassets */; };
 		C2F130FF2B750EFC0079B2DF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C2F130FD2B750EFC0079B2DF /* LaunchScreen.storyboard */; };
+		F0E27E5A25E02857FEE2FFBA /* Test4_RowJScenarioTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EECA945D43D0FFB90466EF39 /* Test4_RowJScenarioTests.swift */; };
 /* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		7386ED1A667820DA56E24EC7 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C2F130E72B750EF80079B2DF /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = C2F130EE2B750EF80079B2DF;
+			remoteInfo = sampleSwift;
+		};
+/* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
 		C2D162F92B9F4741002E6085 /* Embed Frameworks */ = {
@@ -41,13 +60,18 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		1F9F52BFC93E9D1FD0C86D49 /* Test0_DiagnosticTest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Test0_DiagnosticTest.swift; sourceTree = "<group>"; };
+		3ECC2AC04396067BC238F21B /* Test2_ConsentFlowTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Test2_ConsentFlowTests.swift; sourceTree = "<group>"; };
 		4D2D1AE32BE871C800C114EC /* WebViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WebViewController.swift; sourceTree = "<group>"; };
+		550778A01D2C1E74652633FB /* sampleSwiftUITests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = sampleSwiftUITests.swift; sourceTree = "<group>"; };
 		5C0AD4A42E6060FD0018022E /* ConfigurationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurationViewController.swift; sourceTree = "<group>"; };
 		5C0AD4A52E6060FD0018022E /* VendorConsentViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VendorConsentViewController.swift; sourceTree = "<group>"; };
 		5C3009D62E60F32B002D98CA /* ConfigurationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurationManager.swift; sourceTree = "<group>"; };
+		96402763F6C1351AFFBA1C9A /* sampleSwiftUITestsLaunchTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = sampleSwiftUITestsLaunchTests.swift; sourceTree = "<group>"; };
 		B139B2022CAEEBD900F8C284 /* CookieFields.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CookieFields.swift; sourceTree = "<group>"; };
 		B3AA94F52E43D7B700457A2C /* ConsentDebugViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsentDebugViewController.swift; sourceTree = "<group>"; };
 		BB1111112F0000000000001A /* SwiftUISampleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUISampleView.swift; sourceTree = "<group>"; };
+		BDD2FE39A92DB28C1FBD05EA /* Test1_WidgetDisplayTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Test1_WidgetDisplayTests.swift; sourceTree = "<group>"; };
 		C2AAF8CA2B85EB5500447D7B /* TCFFields.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TCFFields.swift; sourceTree = "<group>"; };
 		C2AAF8CC2B85EF0A00447D7B /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
 		C2D162C32B9B1071002E6085 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
@@ -58,6 +82,11 @@
 		C2F130FB2B750EFC0079B2DF /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		C2F130FE2B750EFC0079B2DF /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		C2F131002B750EFC0079B2DF /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		C57C918E45147761B797D235 /* sampleSwiftUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = sampleSwiftUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		D01A4E45CCDEE08C898B7393 /* AxeptioIntegrationTestsHelper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AxeptioIntegrationTestsHelper.swift; sourceTree = "<group>"; };
+		E2AE64F7CB52569AE78E490E /* Test3_PersistenceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Test3_PersistenceTests.swift; sourceTree = "<group>"; };
+		EECA945D43D0FFB90466EF39 /* Test4_RowJScenarioTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Test4_RowJScenarioTests.swift; sourceTree = "<group>"; };
+		F44A27F34A1D1E5198AFA0F4 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -71,9 +100,41 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		F9B4ACCE56CDD376779DB652 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2F5E764B8C7FB4D6853EFB02 /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		054939361E5E18E18ECC6B6D /* iOS */ = {
+			isa = PBXGroup;
+			children = (
+				F44A27F34A1D1E5198AFA0F4 /* Foundation.framework */,
+			);
+			name = iOS;
+			sourceTree = "<group>";
+		};
+		2A3D437901A512F9CF42E586 /* sampleSwiftUITests */ = {
+			isa = PBXGroup;
+			children = (
+				D01A4E45CCDEE08C898B7393 /* AxeptioIntegrationTestsHelper.swift */,
+				1F9F52BFC93E9D1FD0C86D49 /* Test0_DiagnosticTest.swift */,
+				BDD2FE39A92DB28C1FBD05EA /* Test1_WidgetDisplayTests.swift */,
+				3ECC2AC04396067BC238F21B /* Test2_ConsentFlowTests.swift */,
+				E2AE64F7CB52569AE78E490E /* Test3_PersistenceTests.swift */,
+				EECA945D43D0FFB90466EF39 /* Test4_RowJScenarioTests.swift */,
+				550778A01D2C1E74652633FB /* sampleSwiftUITests.swift */,
+				96402763F6C1351AFFBA1C9A /* sampleSwiftUITestsLaunchTests.swift */,
+			);
+			name = sampleSwiftUITests;
+			path = sampleSwiftUITests;
+			sourceTree = "<group>";
+		};
 		C2AAF8D62B86034300447D7B /* View */ = {
 			isa = PBXGroup;
 			children = (
@@ -94,6 +155,7 @@
 				C2F130F12B750EF80079B2DF /* sampleSwift */,
 				C2F130F02B750EF80079B2DF /* Products */,
 				C2F131932B753D450079B2DF /* Frameworks */,
+				2A3D437901A512F9CF42E586 /* sampleSwiftUITests */,
 			);
 			sourceTree = "<group>";
 		};
@@ -101,6 +163,7 @@
 			isa = PBXGroup;
 			children = (
 				C2F130EF2B750EF80079B2DF /* sampleSwift.app */,
+				C57C918E45147761B797D235 /* sampleSwiftUITests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -125,6 +188,7 @@
 		C2F131932B753D450079B2DF /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				054939361E5E18E18ECC6B6D /* iOS */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -132,6 +196,24 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		4352D656DE8BE067A280E8AB /* sampleSwiftUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 6962F41A51E242F4F7F41FDD /* Build configuration list for PBXNativeTarget "sampleSwiftUITests" */;
+			buildPhases = (
+				8BF4912EACDC9D9DC946EE9A /* Sources */,
+				F9B4ACCE56CDD376779DB652 /* Frameworks */,
+				1F918C9994DF23ED31EC45AC /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				E701F6F0D34E3A3DA5AB65E9 /* PBXTargetDependency */,
+			);
+			name = sampleSwiftUITests;
+			productName = sampleSwiftUITests;
+			productReference = C57C918E45147761B797D235 /* sampleSwiftUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
 		C2F130EE2B750EF80079B2DF /* sampleSwift */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = C2F131192B750EFC0079B2DF /* Build configuration list for PBXNativeTarget "sampleSwift" */;
@@ -189,11 +271,19 @@
 			projectRoot = "";
 			targets = (
 				C2F130EE2B750EF80079B2DF /* sampleSwift */,
+				4352D656DE8BE067A280E8AB /* sampleSwiftUITests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		1F918C9994DF23ED31EC45AC /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		C2F130ED2B750EF80079B2DF /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -208,6 +298,21 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		8BF4912EACDC9D9DC946EE9A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6413B8311E7846405DE58C7F /* AxeptioIntegrationTestsHelper.swift in Sources */,
+				69319B09ACBA85ECA9B67CE6 /* Test0_DiagnosticTest.swift in Sources */,
+				44F2AE902CE87B661427D9C9 /* Test1_WidgetDisplayTests.swift in Sources */,
+				20418CC8FF6A336BFA7EDD34 /* Test2_ConsentFlowTests.swift in Sources */,
+				959DE2ECF071305834FA50D5 /* Test3_PersistenceTests.swift in Sources */,
+				F0E27E5A25E02857FEE2FFBA /* Test4_RowJScenarioTests.swift in Sources */,
+				2D3DBF3EB8979EFF061D10B2 /* sampleSwiftUITests.swift in Sources */,
+				931FCBC4DDB8DB500F15FB43 /* sampleSwiftUITestsLaunchTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		C2F130EB2B750EF80079B2DF /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -227,6 +332,15 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		E701F6F0D34E3A3DA5AB65E9 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = sampleSwift;
+			target = C2F130EE2B750EF80079B2DF /* sampleSwift */;
+			targetProxy = 7386ED1A667820DA56E24EC7 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
 		C2F130F82B750EF80079B2DF /* Main.storyboard */ = {
@@ -248,6 +362,27 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		1EA6D7A93E4729E391EFA5F5 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = io.axeptio.sampleSwiftUITests;
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = sampleSwift;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
 		C2F131172B750EFC0079B2DF /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -451,9 +586,38 @@
 			};
 			name = Release;
 		};
+		D2C40E98B327E764A5DA4D5C /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = io.axeptio.sampleSwiftUITests;
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = sampleSwift;
+			};
+			name = Debug;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		6962F41A51E242F4F7F41FDD /* Build configuration list for PBXNativeTarget "sampleSwiftUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				1EA6D7A93E4729E391EFA5F5 /* Release */,
+				D2C40E98B327E764A5DA4D5C /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		C2F130EA2B750EF80079B2DF /* Build configuration list for PBXProject "sampleSwift" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -480,7 +644,7 @@
 			repositoryURL = "https://github.com/axeptio/axeptio-ios-sdk";
 			requirement = {
 				kind = exactVersion;
-				version = "2.2.0";
+				version = 2.2.0;
 			};
 		};
 		C2AAF8D02B85F42A00447D7B /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {

--- a/sampleSwift/sampleSwift.xcodeproj/project.pbxproj
+++ b/sampleSwift/sampleSwift.xcodeproj/project.pbxproj
@@ -9,7 +9,6 @@
 /* Begin PBXBuildFile section */
 		20418CC8FF6A336BFA7EDD34 /* Test2_ConsentFlowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ECC2AC04396067BC238F21B /* Test2_ConsentFlowTests.swift */; };
 		2D3DBF3EB8979EFF061D10B2 /* sampleSwiftUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 550778A01D2C1E74652633FB /* sampleSwiftUITests.swift */; };
-		2F5E764B8C7FB4D6853EFB02 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F44A27F34A1D1E5198AFA0F4 /* Foundation.framework */; };
 		44F2AE902CE87B661427D9C9 /* Test1_WidgetDisplayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDD2FE39A92DB28C1FBD05EA /* Test1_WidgetDisplayTests.swift */; };
 		4D2D1AE42BE871C800C114EC /* WebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D2D1AE32BE871C800C114EC /* WebViewController.swift */; };
 		5C0AD4A62E6060FD0018022E /* ConfigurationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C0AD4A42E6060FD0018022E /* ConfigurationViewController.swift */; };
@@ -86,7 +85,6 @@
 		D01A4E45CCDEE08C898B7393 /* AxeptioIntegrationTestsHelper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AxeptioIntegrationTestsHelper.swift; sourceTree = "<group>"; };
 		E2AE64F7CB52569AE78E490E /* Test3_PersistenceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Test3_PersistenceTests.swift; sourceTree = "<group>"; };
 		EECA945D43D0FFB90466EF39 /* Test4_RowJScenarioTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Test4_RowJScenarioTests.swift; sourceTree = "<group>"; };
-		F44A27F34A1D1E5198AFA0F4 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -104,7 +102,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				2F5E764B8C7FB4D6853EFB02 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -114,7 +111,6 @@
 		054939361E5E18E18ECC6B6D /* iOS */ = {
 			isa = PBXGroup;
 			children = (
-				F44A27F34A1D1E5198AFA0F4 /* Foundation.framework */,
 			);
 			name = iOS;
 			sourceTree = "<group>";

--- a/sampleSwift/sampleSwift.xcodeproj/xcshareddata/xcschemes/sampleSwift.xcscheme
+++ b/sampleSwift/sampleSwift.xcodeproj/xcshareddata/xcschemes/sampleSwift.xcscheme
@@ -34,18 +34,7 @@
             parallelizable = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "C2F131042B750EFC0079B2DF"
-               BuildableName = "sampleSwiftTests.xctest"
-               BlueprintName = "sampleSwiftTests"
-               ReferencedContainer = "container:sampleSwift.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO"
-            parallelizable = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "C2F1310E2B750EFC0079B2DF"
+               BlueprintIdentifier = "4352D656DE8BE067A280E8AB"
                BuildableName = "sampleSwiftUITests.xctest"
                BlueprintName = "sampleSwiftUITests"
                ReferencedContainer = "container:sampleSwift.xcodeproj">

--- a/sampleSwift/sampleSwiftUITests/AxeptioIntegrationTestsHelper.swift
+++ b/sampleSwift/sampleSwiftUITests/AxeptioIntegrationTestsHelper.swift
@@ -51,6 +51,31 @@ class AxeptioIntegrationTestsHelper {
         }
     }
 
+    /// Wait for the first element matching any of `labels` in any of `queries`.
+    ///
+    /// The `timeout` is a single budget shared across every label, not granted to each in
+    /// turn: waiting `timeout` per label made a 5s call block for 15s across three labels.
+    /// Polling (rather than an immediate `.exists` check) matters for web content, where the
+    /// consent DOM is populated some time after the enclosing webview starts to exist.
+    func waitForFirstMatch(
+        labels: [String],
+        in queries: [XCUIElementQuery],
+        timeout: TimeInterval
+    ) -> XCUIElement? {
+        let deadline = Date().addingTimeInterval(timeout)
+
+        repeat {
+            for query in queries {
+                for label in labels where query[label].exists {
+                    return query[label]
+                }
+            }
+            Thread.sleep(forTimeInterval: 0.25)
+        } while Date() < deadline
+
+        return nil
+    }
+
     /// Tap the "Consent pop up" button in sampleSwift to trigger widget display
     @discardableResult
     func tapShowConsentButton(timeout: TimeInterval = 5.0) -> Bool {
@@ -61,17 +86,14 @@ class AxeptioIntegrationTestsHelper {
             "Brands Consent Dialog"
         ]
 
-        for label in buttonLabels {
-            let button = app.buttons[label]
-            if button.waitForExistence(timeout: timeout) {
-                button.tap()
-                print("✅ Tapped '\(label)' button to show widget")
-                return true
-            }
+        guard let button = waitForFirstMatch(labels: buttonLabels, in: [app.buttons], timeout: timeout) else {
+            print("❌ Show consent button not found (tried: \(buttonLabels.joined(separator: ", ")))")
+            return false
         }
 
-        print("❌ Show consent button not found (tried: \(buttonLabels.joined(separator: ", ")))")
-        return false
+        button.tap()
+        print("✅ Tapped '\(button.label)' button to show widget")
+        return true
     }
 
     /// Tap the "Clear consent" button in sampleSwift to reset consent state
@@ -145,7 +167,12 @@ class AxeptioIntegrationTestsHelper {
     /// - Returns: True if widget is no longer visible
     func waitForWidgetToDisappear(timeout: TimeInterval = 5.0) -> Bool {
         let webView = app.webViews.firstMatch
-        let disappeared = !webView.waitForExistence(timeout: timeout)
+
+        // Must be waitForNonExistence, not !waitForExistence: the latter returns true
+        // immediately when the element is already on screen, so it reported "still visible"
+        // without ever waiting, and conversely burned the whole timeout to report success
+        // when the widget had never appeared at all.
+        let disappeared = webView.waitForNonExistence(timeout: timeout)
 
         if disappeared {
             print("✅ Widget disappeared")
@@ -164,6 +191,10 @@ class AxeptioIntegrationTestsHelper {
     /// - Returns: True if button was found and tapped
     @discardableResult
     func tapAcceptButton(timeout: TimeInterval = 5.0) -> Bool {
+        // `timeout` is a single budget covering both the webview appearing and its
+        // buttons rendering, so the caller's number means what it says.
+        let start = Date()
+
         // Wait for WebView to load
         let webView = app.webViews.firstMatch
         guard webView.waitForExistence(timeout: timeout) else {
@@ -181,22 +212,17 @@ class AxeptioIntegrationTestsHelper {
             "J'accepte"
         ]
 
-        for label in buttonLabels {
-            // Look in WebView first
-            let button = webView.buttons[label]
-            if button.exists {
-                button.tap()
-                print("✅ Tapped accept button: '\(label)'")
-                return true
-            }
-
-            // Also check outside WebView (in case button is native)
-            let nativeButton = app.buttons[label]
-            if nativeButton.exists {
-                nativeButton.tap()
-                print("✅ Tapped native accept button: '\(label)'")
-                return true
-            }
+        // Poll for the remaining budget rather than checking .exists once: the webview
+        // existing does not mean the consent DOM inside it has rendered yet.
+        let remaining = max(0, timeout - Date().timeIntervalSince(start))
+        if let button = waitForFirstMatch(
+            labels: buttonLabels,
+            in: [webView.buttons, app.buttons],
+            timeout: remaining
+        ) {
+            button.tap()
+            print("✅ Tapped accept button: '\(button.label)'")
+            return true
         }
 
         // Try finding button with partial match
@@ -216,6 +242,10 @@ class AxeptioIntegrationTestsHelper {
     /// - Returns: True if button was found and tapped
     @discardableResult
     func tapRejectButton(timeout: TimeInterval = 5.0) -> Bool {
+        // As with tapAcceptButton, `timeout` covers both the webview appearing and its
+        // buttons rendering.
+        let start = Date()
+
         let webView = app.webViews.firstMatch
         guard webView.waitForExistence(timeout: timeout) else {
             print("❌ WebView not found, cannot tap reject button")
@@ -230,17 +260,19 @@ class AxeptioIntegrationTestsHelper {
             "Tout refuser"
         ]
 
-        for label in buttonLabels {
-            let button = webView.buttons[label]
-            if button.exists {
-                button.tap()
-                print("✅ Tapped reject button: '\(label)'")
-                return true
-            }
+        let remaining = max(0, timeout - Date().timeIntervalSince(start))
+        guard let button = waitForFirstMatch(
+            labels: buttonLabels,
+            in: [webView.buttons, app.buttons],
+            timeout: remaining
+        ) else {
+            print("❌ Reject button not found")
+            return false
         }
 
-        print("❌ Reject button not found")
-        return false
+        button.tap()
+        print("✅ Tapped reject button: '\(button.label)'")
+        return true
     }
 
     // MARK: - Screenshots

--- a/sampleSwift/sampleSwiftUITests/AxeptioIntegrationTestsHelper.swift
+++ b/sampleSwift/sampleSwiftUITests/AxeptioIntegrationTestsHelper.swift
@@ -84,8 +84,11 @@ class AxeptioIntegrationTestsHelper {
             "clear consent"
         ]
 
-        // Debug: Print all available buttons
-        print("  [Debug] Available buttons: \(app.buttons.allElementsBoundByIndex.map { $0.label }.joined(separator: ", "))")
+        // Debug: report only the button count. Enumerating allElementsBoundByIndex
+        // and reading each .label takes a fresh accessibility snapshot per element,
+        // which throws "No matches found for Element at index N" whenever an element
+        // goes stale mid-iteration (common once the consent webview is on screen).
+        print("  [Debug] Available buttons: \(app.buttons.count)")
 
         for label in buttonLabels {
             let button = app.buttons[label]

--- a/sampleSwift/sampleSwiftUITests/AxeptioIntegrationTestsHelper.swift
+++ b/sampleSwift/sampleSwiftUITests/AxeptioIntegrationTestsHelper.swift
@@ -1,0 +1,287 @@
+//
+//  AxeptioIntegrationTestsHelper.swift
+//  AxeptioSDK Integration Tests
+//
+//  Created by Claude Sonnet 4.5 on 29/12/2024.
+//  MSK-140: XCUITest-based integration tests for Axeptio SDK
+//
+
+import XCTest
+
+/// Helper utilities for Axeptio integration tests
+class AxeptioIntegrationTestsHelper {
+
+    let app: XCUIApplication
+
+    init(app: XCUIApplication) {
+        self.app = app
+    }
+
+    // MARK: - App Lifecycle
+
+    /// Launch the app with clean state in portrait orientation
+    func launchApp() {
+        // Aggressively lock orientation to portrait
+        XCUIDevice.shared.orientation = .portrait
+        app.launch()
+
+        // Re-enforce portrait multiple times during stabilization
+        for _ in 0..<3 {
+            sleep(1)
+            if XCUIDevice.shared.orientation != .portrait {
+                print("  [Debug] Correcting orientation back to portrait")
+                XCUIDevice.shared.orientation = .portrait
+            }
+        }
+    }
+
+    /// Terminate and relaunch the app
+    func relaunchApp() {
+        app.terminate()
+        sleep(1) // Wait for clean termination
+        launchApp() // Use launchApp to get portrait locking
+    }
+
+    /// Force device to portrait orientation
+    func enforcePortraitOrientation() {
+        if XCUIDevice.shared.orientation != .portrait {
+            print("  [Debug] Forcing portrait orientation")
+            XCUIDevice.shared.orientation = .portrait
+            sleep(1)
+        }
+    }
+
+    /// Tap the "Consent pop up" button in sampleSwift to trigger widget display
+    @discardableResult
+    func tapShowConsentButton(timeout: TimeInterval = 5.0) -> Bool {
+        // Button label can be "Consent pop up", "TCF Consent Dialog", or "Brands Consent Dialog"
+        let buttonLabels = [
+            "Consent pop up",
+            "TCF Consent Dialog",
+            "Brands Consent Dialog"
+        ]
+
+        for label in buttonLabels {
+            let button = app.buttons[label]
+            if button.waitForExistence(timeout: timeout) {
+                button.tap()
+                print("✅ Tapped '\(label)' button to show widget")
+                return true
+            }
+        }
+
+        print("❌ Show consent button not found (tried: \(buttonLabels.joined(separator: ", ")))")
+        return false
+    }
+
+    /// Tap the "Clear consent" button in sampleSwift to reset consent state
+    @discardableResult
+    func tapClearConsentButton(timeout: TimeInterval = 5.0) -> Bool {
+        // Try multiple button label variations
+        let buttonLabels = [
+            "Clear consent",
+            "Clear Consent",
+            "clear consent"
+        ]
+
+        // Debug: Print all available buttons
+        print("  [Debug] Available buttons: \(app.buttons.allElementsBoundByIndex.map { $0.label }.joined(separator: ", "))")
+
+        for label in buttonLabels {
+            let button = app.buttons[label]
+            if button.waitForExistence(timeout: timeout / Double(buttonLabels.count)) {
+                button.tap()
+                print("✅ Tapped '\(label)' button")
+                // Wait for the confirmation (button briefly shows "✅ Cleared!")
+                sleep(1)
+                return true
+            }
+        }
+
+        // Try partial match as fallback
+        let partialMatch = app.buttons.containing(NSPredicate(format: "label CONTAINS[c] 'clear' AND label CONTAINS[c] 'consent'")).firstMatch
+        if partialMatch.exists {
+            partialMatch.tap()
+            print("✅ Tapped clear consent button (partial match)")
+            sleep(1)
+            return true
+        }
+
+        print("❌ Clear consent button not found (tried: \(buttonLabels.joined(separator: ", ")))")
+        return false
+    }
+
+    // MARK: - Widget Detection
+
+    /// Check if the Axeptio consent widget is displayed
+    /// - Parameter timeout: Maximum time to wait for widget (default: 5 seconds)
+    /// - Returns: True if widget is visible
+    func isWidgetDisplayed(timeout: TimeInterval = 5.0) -> Bool {
+        // Look for WebView or consent-related elements
+        let webView = app.webViews.firstMatch
+        let exists = webView.waitForExistence(timeout: timeout)
+
+        if exists {
+            print("✅ Widget detected: WebView found")
+            return true
+        }
+
+        // Alternative: Look for specific consent button text
+        let acceptButton = app.buttons.containing(NSPredicate(format: "label CONTAINS[c] 'accept' OR label CONTAINS[c] 'accepter'")).firstMatch
+        if acceptButton.exists {
+            print("✅ Widget detected: Accept button found")
+            return true
+        }
+
+        print("❌ Widget not detected")
+        return false
+    }
+
+    /// Wait for the widget to disappear
+    /// - Parameter timeout: Maximum time to wait (default: 5 seconds)
+    /// - Returns: True if widget is no longer visible
+    func waitForWidgetToDisappear(timeout: TimeInterval = 5.0) -> Bool {
+        let webView = app.webViews.firstMatch
+        let disappeared = !webView.waitForExistence(timeout: timeout)
+
+        if disappeared {
+            print("✅ Widget disappeared")
+        } else {
+            print("⚠️ Widget still visible after timeout")
+        }
+
+        return disappeared
+    }
+
+    // MARK: - Consent Actions
+
+    /// Tap the "Accept" button in the consent widget
+    /// Tries multiple language variants (English, French)
+    /// - Parameter timeout: Maximum time to wait for button (default: 5 seconds)
+    /// - Returns: True if button was found and tapped
+    @discardableResult
+    func tapAcceptButton(timeout: TimeInterval = 5.0) -> Bool {
+        // Wait for WebView to load
+        let webView = app.webViews.firstMatch
+        guard webView.waitForExistence(timeout: timeout) else {
+            print("❌ WebView not found, cannot tap accept button")
+            return false
+        }
+
+        // Try multiple button label variations
+        let buttonLabels = [
+            "OK!",                // Brands consent dialog
+            "Accept",
+            "Accept all",
+            "Accepter",
+            "Tout accepter",
+            "J'accepte"
+        ]
+
+        for label in buttonLabels {
+            // Look in WebView first
+            let button = webView.buttons[label]
+            if button.exists {
+                button.tap()
+                print("✅ Tapped accept button: '\(label)'")
+                return true
+            }
+
+            // Also check outside WebView (in case button is native)
+            let nativeButton = app.buttons[label]
+            if nativeButton.exists {
+                nativeButton.tap()
+                print("✅ Tapped native accept button: '\(label)'")
+                return true
+            }
+        }
+
+        // Try finding button with partial match
+        let partialMatch = webView.buttons.containing(NSPredicate(format: "label CONTAINS[c] 'accept'")).firstMatch
+        if partialMatch.exists {
+            partialMatch.tap()
+            print("✅ Tapped accept button (partial match)")
+            return true
+        }
+
+        print("❌ Accept button not found")
+        return false
+    }
+
+    /// Tap the "Reject" button in the consent widget
+    /// - Parameter timeout: Maximum time to wait for button (default: 5 seconds)
+    /// - Returns: True if button was found and tapped
+    @discardableResult
+    func tapRejectButton(timeout: TimeInterval = 5.0) -> Bool {
+        let webView = app.webViews.firstMatch
+        guard webView.waitForExistence(timeout: timeout) else {
+            print("❌ WebView not found, cannot tap reject button")
+            return false
+        }
+
+        let buttonLabels = [
+            "No, thanks",         // Brands consent dialog
+            "Reject",
+            "Reject all",
+            "Refuser",
+            "Tout refuser"
+        ]
+
+        for label in buttonLabels {
+            let button = webView.buttons[label]
+            if button.exists {
+                button.tap()
+                print("✅ Tapped reject button: '\(label)'")
+                return true
+            }
+        }
+
+        print("❌ Reject button not found")
+        return false
+    }
+
+    // MARK: - Screenshots
+
+    /// Take a screenshot with a descriptive name
+    /// - Parameter name: Name for the screenshot
+    /// - Returns: XCTAttachment with the screenshot
+    @discardableResult
+    func takeScreenshot(named name: String) -> XCTAttachment {
+        let screenshot = XCUIScreen.main.screenshot()
+        let attachment = XCTAttachment(screenshot: screenshot)
+        attachment.name = name
+        attachment.lifetime = .keepAlways
+        print("📸 Screenshot taken: \(name)")
+        return attachment
+    }
+
+    // MARK: - UserDefaults Helpers
+
+    /// Clear all UserDefaults (requires app to expose this functionality)
+    /// Note: This is a placeholder - actual implementation depends on app structure
+    func clearUserDefaults() {
+        // In a real scenario, you might need to:
+        // 1. Uninstall/reinstall the app
+        // 2. Have the app expose a debug API
+        // 3. Use launch arguments to trigger reset
+
+        print("⚠️ UserDefaults clearing requires app support or reinstall")
+    }
+
+    // MARK: - Wait Helpers
+
+    /// Wait for a specific element to appear
+    /// - Parameters:
+    ///   - element: The UI element to wait for
+    ///   - timeout: Maximum wait time
+    /// - Returns: True if element appeared
+    func waitForElement(_ element: XCUIElement, timeout: TimeInterval = 5.0) -> Bool {
+        let exists = element.waitForExistence(timeout: timeout)
+        if exists {
+            print("✅ Element appeared: \(element.debugDescription)")
+        } else {
+            print("❌ Element did not appear within \(timeout)s")
+        }
+        return exists
+    }
+}

--- a/sampleSwift/sampleSwiftUITests/Test0_DiagnosticTest.swift
+++ b/sampleSwift/sampleSwiftUITests/Test0_DiagnosticTest.swift
@@ -1,0 +1,158 @@
+//
+//  Test0_DiagnosticTest.swift
+//  AxeptioSDK Integration Tests
+//
+//  Diagnostic test to verify button detection and orientation fixes
+//  Run this single test first to diagnose issues before running full suite
+//
+//  Created by Claude Sonnet 4.5 on 29/12/2024.
+//  MSK-140: XCUITest diagnostic utilities
+//
+
+import XCTest
+
+class Test0_DiagnosticTest: XCTestCase {
+
+    var app: XCUIApplication!
+    var helper: AxeptioIntegrationTestsHelper!
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+
+        // Lock device to portrait orientation
+        XCUIDevice.shared.orientation = .portrait
+
+        app = XCUIApplication()
+        helper = AxeptioIntegrationTestsHelper(app: app)
+    }
+
+    override func tearDownWithError() throws {
+        app.terminate()
+        app = nil
+        helper = nil
+    }
+
+    // MARK: - Diagnostic Test: Button Detection
+
+    func testDiagnostic_ClearConsentButtonDetection() throws {
+        // Diagnostic test to verify Clear consent button can be found
+        print("🔍 Diagnostic Test: Clear Consent Button Detection")
+
+        // Launch app
+        print("  [1/4] Launching app...")
+        helper.launchApp()
+        sleep(2)
+
+        // Check orientation
+        let orientation = XCUIDevice.shared.orientation
+        print("  [2/4] Device orientation: \(orientation.rawValue) (portrait=1)")
+        XCTAssertEqual(orientation, .portrait, "Device should be in portrait orientation")
+
+        // Try to find and tap clear consent button
+        print("  [3/4] Attempting to find Clear consent button...")
+        let clearResult = helper.tapClearConsentButton(timeout: 5.0)
+
+        // Take screenshot regardless of result
+        let screenshot = helper.takeScreenshot(named: "Diagnostic_ClearConsent_\(clearResult ? "Success" : "Failed")")
+        add(screenshot)
+
+        print("  [4/4] Result: \(clearResult ? "✅ SUCCESS" : "❌ FAILED")")
+
+        if clearResult {
+            print("  ✅ Diagnostic PASSED: Clear consent button was found and tapped")
+        } else {
+            print("  ❌ Diagnostic FAILED: Clear consent button was NOT found")
+            print("  Check the screenshot and debug output above to see what buttons are available")
+        }
+
+        // Don't fail the test - this is diagnostic only
+        // XCTAssertTrue(clearResult, "Clear consent button should be found")
+    }
+
+    // MARK: - Diagnostic Test: Widget Auto-Display
+
+    func testDiagnostic_WidgetAutoDisplay() throws {
+        // Diagnostic test to verify widget auto-displays after clearing consent
+        print("🔍 Diagnostic Test: Widget Auto-Display")
+
+        // STEP 1: Launch and clear consent
+        print("  [1/5] Launching app...")
+        helper.launchApp()
+        sleep(2)
+
+        print("  [2/5] Clearing consent...")
+        let clearResult = helper.tapClearConsentButton(timeout: 5.0)
+
+        let screenshot1 = helper.takeScreenshot(named: "Diagnostic_AutoDisplay_1_AfterClear")
+        add(screenshot1)
+
+        if !clearResult {
+            print("  ⚠️ Could not clear consent - skipping rest of test")
+            return
+        }
+
+        // STEP 2: Terminate app
+        print("  [3/5] Terminating app...")
+        app.terminate()
+        sleep(2)
+
+        // STEP 3: Relaunch for auto-display
+        print("  [4/5] Relaunching app for auto-display...")
+        helper.launchApp()
+        sleep(3)
+
+        // STEP 4: Check if widget displays
+        print("  [5/5] Checking if widget auto-displays...")
+        let widgetDisplayed = helper.isWidgetDisplayed(timeout: 5.0)
+
+        let screenshot2 = helper.takeScreenshot(named: "Diagnostic_AutoDisplay_2_AfterRelaunch")
+        add(screenshot2)
+
+        if widgetDisplayed {
+            print("  ✅ Diagnostic PASSED: Widget auto-displayed after clearing consent")
+        } else {
+            print("  ❌ Diagnostic FAILED: Widget did NOT auto-display")
+            print("  This suggests either:")
+            print("    - Consent was not actually cleared")
+            print("    - Widget configuration doesn't auto-display")
+            print("    - App state issue")
+        }
+
+        // Don't fail the test - this is diagnostic only
+        // XCTAssertTrue(widgetDisplayed, "Widget should auto-display after clearing consent")
+    }
+
+    // MARK: - Diagnostic Test: Portrait Orientation Lock
+
+    func testDiagnostic_PortraitOrientationLock() throws {
+        // Diagnostic test to verify orientation stays portrait
+        print("🔍 Diagnostic Test: Portrait Orientation Lock")
+
+        print("  [1/4] Initial orientation: \(XCUIDevice.shared.orientation.rawValue)")
+
+        print("  [2/4] Launching app...")
+        helper.launchApp()
+
+        sleep(2)
+        let orientationAfterLaunch = XCUIDevice.shared.orientation
+        print("  [3/4] Orientation after launch: \(orientationAfterLaunch.rawValue) (portrait=1)")
+
+        sleep(2)
+        let orientationAfterWait = XCUIDevice.shared.orientation
+        print("  [4/4] Orientation after 2s wait: \(orientationAfterWait.rawValue)")
+
+        let screenshot = helper.takeScreenshot(named: "Diagnostic_Orientation")
+        add(screenshot)
+
+        if orientationAfterLaunch == .portrait && orientationAfterWait == .portrait {
+            print("  ✅ Diagnostic PASSED: Orientation stayed portrait")
+        } else {
+            print("  ❌ Diagnostic FAILED: Orientation changed")
+            print("    After launch: \(orientationAfterLaunch.rawValue)")
+            print("    After wait: \(orientationAfterWait.rawValue)")
+        }
+
+        // Don't fail the test - this is diagnostic only
+        // XCTAssertEqual(orientationAfterWait, .portrait, "Orientation should stay portrait")
+    }
+}

--- a/sampleSwift/sampleSwiftUITests/Test0_DiagnosticTest.swift
+++ b/sampleSwift/sampleSwiftUITests/Test0_DiagnosticTest.swift
@@ -17,6 +17,14 @@ class Test0_DiagnosticTest: XCTestCase {
     var helper: AxeptioIntegrationTestsHelper!
 
     override func setUpWithError() throws {
+        // These tests deliberately assert nothing — they exist to print what the accessibility
+        // tree looks like when something else is failing. Run as part of the nightly suite they
+        // add launches and screenshots while producing no pass/fail signal, so they are opt-in.
+        try XCTSkipUnless(
+            ProcessInfo.processInfo.environment["AXEPTIO_RUN_DIAGNOSTICS"] == "1",
+            "Set AXEPTIO_RUN_DIAGNOSTICS=1 to run the diagnostic (non-asserting) tests."
+        )
+
         continueAfterFailure = false
 
         // Lock device to portrait orientation
@@ -27,7 +35,9 @@ class Test0_DiagnosticTest: XCTestCase {
     }
 
     override func tearDownWithError() throws {
-        app.terminate()
+        // tearDown still runs when setUp throws XCTSkip, at which point `app` was never
+        // assigned — terminating an implicitly-unwrapped nil would crash the run.
+        app?.terminate()
         app = nil
         helper = nil
     }

--- a/sampleSwift/sampleSwiftUITests/Test1_WidgetDisplayTests.swift
+++ b/sampleSwift/sampleSwiftUITests/Test1_WidgetDisplayTests.swift
@@ -1,0 +1,188 @@
+//
+//  Test1_WidgetDisplayTests.swift
+//  AxeptioSDK Integration Tests
+//
+//  Test Scenario 1: Widget Display Verification
+//  Validates that the Axeptio consent widget displays correctly when the app launches
+//
+//  Created by Claude Sonnet 4.5 on 29/12/2024.
+//  MSK-140: XCUITest-based integration tests
+//
+
+import XCTest
+
+class Test1_WidgetDisplayTests: XCTestCase {
+
+    var app: XCUIApplication!
+    var helper: AxeptioIntegrationTestsHelper!
+
+    override func setUpWithError() throws {
+        // Stop immediately when a failure occurs
+        continueAfterFailure = false
+
+        // Lock device to portrait orientation
+        XCUIDevice.shared.orientation = .portrait
+
+        // Initialize app
+        app = XCUIApplication()
+        helper = AxeptioIntegrationTestsHelper(app: app)
+    }
+
+    override func tearDownWithError() throws {
+        // Terminate app after each test
+        app.terminate()
+        app = nil
+        helper = nil
+    }
+
+    // MARK: - Test 1: Widget Display on First Launch
+
+    func testWidgetDisplaysOnFirstLaunch() throws {
+        // Given: Consent is cleared and app is relaunched for auto-display
+        print("🧪 Test 1: Widget Display on First Launch")
+
+        // Launch app to clear consent
+        helper.launchApp()
+        sleep(2)
+
+        // Clear existing consent
+        print("  Clearing consent...")
+        helper.tapClearConsentButton(timeout: 3.0)
+        sleep(1)
+
+        // Terminate and relaunch for auto-display
+        print("  Terminating app...")
+        app.terminate()
+        sleep(2)
+
+        // When: App is relaunched after consent cleared
+        print("  Relaunching app...")
+        helper.launchApp()
+        sleep(2)
+
+        // Then: Consent widget should auto-display
+        let widgetDisplayed = helper.isWidgetDisplayed(timeout: 5.0)
+        XCTAssertTrue(widgetDisplayed, "Axeptio consent widget should auto-display on launch after consent cleared")
+
+        // Take screenshot for visual verification
+        let screenshot = helper.takeScreenshot(named: "Test1_WidgetDisplay_FirstLaunch")
+        add(screenshot)
+
+        print("✅ Test 1 Passed: Widget auto-displayed on first launch")
+    }
+
+    // MARK: - Test 2: Widget Contains Expected Elements
+
+    func testWidgetContainsExpectedElements() throws {
+        // Given: Consent is cleared and app is relaunched for auto-display
+        print("🧪 Test 2: Widget Contains Expected Elements")
+
+        helper.launchApp()
+        sleep(2)
+
+        // Clear existing consent
+        print("  Clearing consent...")
+        helper.tapClearConsentButton(timeout: 3.0)
+        sleep(1)
+
+        // Terminate and relaunch for auto-display
+        app.terminate()
+        sleep(2)
+
+        helper.launchApp()
+        sleep(2)
+
+        // Verify widget auto-displays
+        XCTAssertTrue(helper.isWidgetDisplayed(timeout: 5.0), "Widget should auto-display")
+
+        // Then: WebView should be present
+        let webView = app.webViews.firstMatch
+        XCTAssertTrue(webView.exists, "WebView should exist in the widget")
+
+        // Check for consent buttons inside the WebView (at least one should exist)
+        let hasAcceptButton = webView.buttons.containing(NSPredicate(format: "label CONTAINS[c] 'accept' OR label CONTAINS[c] 'tout accepter'")).firstMatch.exists
+        let hasRejectButton = webView.buttons.containing(NSPredicate(format: "label CONTAINS[c] 'reject' OR label CONTAINS[c] 'refus' OR label CONTAINS[c] 'deny'")).firstMatch.exists
+        let hasAnyButton = webView.buttons.count > 0
+
+        XCTAssertTrue(
+            hasAcceptButton || hasRejectButton || hasAnyButton,
+            "Widget should contain at least one action button (accept or reject). Found \(webView.buttons.count) buttons in WebView"
+        )
+
+        // Take screenshot
+        let screenshot = helper.takeScreenshot(named: "Test2_WidgetElements")
+        add(screenshot)
+
+        print("✅ Test 2 Passed: Widget contains expected elements")
+    }
+
+    // MARK: - Test 3: Widget Loads Within Acceptable Time
+
+    func testWidgetLoadsWithinAcceptableTime() throws {
+        // Given: Consent is cleared
+        print("🧪 Test 3: Widget Loads Within Acceptable Time")
+
+        helper.launchApp()
+        sleep(2)
+
+        // Clear existing consent
+        print("  Clearing consent...")
+        helper.tapClearConsentButton(timeout: 3.0)
+        sleep(1)
+
+        // Terminate app
+        app.terminate()
+        sleep(2)
+
+        // Measure time from launch to widget appearing
+        let startTime = Date()
+
+        // When: App is relaunched
+        helper.launchApp()
+
+        // Then: Widget should auto-display within 10 seconds
+        let widgetAppeared = helper.isWidgetDisplayed(timeout: 10.0)
+        let loadTime = Date().timeIntervalSince(startTime)
+
+        XCTAssertTrue(widgetAppeared, "Widget should auto-display")
+        XCTAssertLessThan(loadTime, 10.0, "Widget should auto-display within 10 seconds")
+
+        print("✅ Test 3 Passed: Widget auto-displayed in \(String(format: "%.2f", loadTime))s")
+    }
+
+    // MARK: - Test 4: Widget Displays After App Backgrounding
+
+    func testWidgetPersistsAfterBackgrounding() throws {
+        // Given: Consent is cleared and app relaunched for auto-display
+        print("🧪 Test 4: Widget Persists After Backgrounding")
+
+        helper.launchApp()
+        sleep(2)
+
+        // Clear existing consent
+        print("  Clearing consent...")
+        helper.tapClearConsentButton(timeout: 3.0)
+        sleep(1)
+
+        // Terminate and relaunch for auto-display
+        app.terminate()
+        sleep(2)
+
+        helper.launchApp()
+        sleep(2)
+
+        XCTAssertTrue(helper.isWidgetDisplayed(), "Widget should auto-display")
+
+        // When: App is sent to background and brought back to foreground
+        XCUIDevice.shared.press(.home)
+        sleep(1)
+        app.activate()
+        sleep(1)
+
+        // Then: Widget should still be displayed
+        let widgetStillDisplayed = helper.isWidgetDisplayed(timeout: 3.0)
+        XCTAssertTrue(widgetStillDisplayed, "Widget should persist after backgrounding")
+
+        print("✅ Test 4 Passed: Widget persists after backgrounding")
+    }
+}

--- a/sampleSwift/sampleSwiftUITests/Test2_ConsentFlowTests.swift
+++ b/sampleSwift/sampleSwiftUITests/Test2_ConsentFlowTests.swift
@@ -119,8 +119,9 @@ class Test2_ConsentFlowTests: XCTestCase {
 
             print("✅ Test 2 Passed: Reject consent flow completed")
         } else {
-            print("⚠️ Test 2 Skipped: Reject button not available in this widget configuration")
-            // This is acceptable - not all widget configurations have a reject button
+            // Report a real skip rather than printing one: a printed "Skipped" still
+            // counts as a pass, which hides missing coverage in CI reports.
+            throw XCTSkip("Reject button not available in this widget configuration")
         }
     }
 
@@ -161,7 +162,7 @@ class Test2_ConsentFlowTests: XCTestCase {
 
             print("✅ Test 3 Passed: Widget close button works")
         } else {
-            print("⚠️ Test 3 Skipped: Close button not available in this widget configuration")
+            throw XCTSkip("Close button not available in this widget configuration")
         }
     }
 
@@ -247,7 +248,7 @@ class Test2_ConsentFlowTests: XCTestCase {
             // The test passing means the app didn't crash
             print("✅ Test 5 Passed: Multiple consent actions handled gracefully")
         } else {
-            print("⚠️ Test 5 Skipped: Accept button not found")
+            throw XCTSkip("Accept button not found")
         }
     }
 }

--- a/sampleSwift/sampleSwiftUITests/Test2_ConsentFlowTests.swift
+++ b/sampleSwift/sampleSwiftUITests/Test2_ConsentFlowTests.swift
@@ -1,0 +1,253 @@
+//
+//  Test2_ConsentFlowTests.swift
+//  AxeptioSDK Integration Tests
+//
+//  Test Scenario 2: Consent Flow Verification
+//  Validates that users can successfully accept/reject consent and the widget responds correctly
+//
+//  Created by Claude Sonnet 4.5 on 29/12/2024.
+//  MSK-140: XCUITest-based integration tests
+//
+
+import XCTest
+
+class Test2_ConsentFlowTests: XCTestCase {
+
+    var app: XCUIApplication!
+    var helper: AxeptioIntegrationTestsHelper!
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+
+        // Lock device to portrait orientation
+        XCUIDevice.shared.orientation = .portrait
+
+        app = XCUIApplication()
+        helper = AxeptioIntegrationTestsHelper(app: app)
+    }
+
+    override func tearDownWithError() throws {
+        app.terminate()
+        app = nil
+        helper = nil
+    }
+
+    // MARK: - Test 1: Accept Consent Flow
+
+    func testAcceptConsentFlow() throws {
+        // Given: Consent is cleared and app relaunched for auto-display
+        print("🧪 Test 1: Accept Consent Flow")
+
+        helper.launchApp()
+        sleep(2)
+
+        // Clear existing consent
+        print("  Clearing consent...")
+        helper.tapClearConsentButton(timeout: 3.0)
+        sleep(1)
+
+        // Terminate and relaunch for auto-display
+        app.terminate()
+        sleep(2)
+
+        helper.launchApp()
+        sleep(2)
+
+        // Verify widget auto-displays
+        XCTAssertTrue(helper.isWidgetDisplayed(), "Widget should auto-display before acceptance")
+
+        // Take "before" screenshot
+        let beforeScreenshot = helper.takeScreenshot(named: "Test2_AcceptFlow_Before")
+        add(beforeScreenshot)
+
+        // When: User taps the "Accept" button
+        let acceptTapped = helper.tapAcceptButton(timeout: 5.0)
+        XCTAssertTrue(acceptTapped, "Accept button should be found and tapped")
+
+        // Wait for widget to process and dismiss
+        sleep(5)
+
+        // Then: Widget should disappear
+        let widgetDismissed = !helper.isWidgetDisplayed(timeout: 5.0)
+        XCTAssertTrue(widgetDismissed, "Widget should disappear after accepting consent")
+
+        // Take "after" screenshot
+        let afterScreenshot = helper.takeScreenshot(named: "Test2_AcceptFlow_After")
+        add(afterScreenshot)
+
+        print("✅ Test 1 Passed: Accept consent flow completed successfully")
+    }
+
+    // MARK: - Test 2: Reject Consent Flow
+
+    func testRejectConsentFlow() throws {
+        // Given: Consent is cleared and app relaunched for auto-display
+        print("🧪 Test 2: Reject Consent Flow")
+
+        helper.launchApp()
+        sleep(2)
+
+        // Clear existing consent
+        print("  Clearing consent...")
+        helper.tapClearConsentButton(timeout: 3.0)
+        sleep(1)
+
+        // Terminate and relaunch for auto-display
+        app.terminate()
+        sleep(2)
+
+        helper.launchApp()
+        sleep(2)
+
+        XCTAssertTrue(helper.isWidgetDisplayed(), "Widget should auto-display before rejection")
+
+        // Take "before" screenshot
+        let beforeScreenshot = helper.takeScreenshot(named: "Test2_RejectFlow_Before")
+        add(beforeScreenshot)
+
+        // When: User taps the "Reject" button
+        let rejectTapped = helper.tapRejectButton(timeout: 5.0)
+
+        if rejectTapped {
+            // If reject button exists and was tapped
+            sleep(2)
+
+            // Then: Widget should disappear or show updated state
+            // Note: Behavior may vary - widget might stay visible to allow changes
+            let afterScreenshot = helper.takeScreenshot(named: "Test2_RejectFlow_After")
+            add(afterScreenshot)
+
+            print("✅ Test 2 Passed: Reject consent flow completed")
+        } else {
+            print("⚠️ Test 2 Skipped: Reject button not available in this widget configuration")
+            // This is acceptable - not all widget configurations have a reject button
+        }
+    }
+
+    // MARK: - Test 3: Widget Close Button
+
+    func testWidgetCloseButton() throws {
+        // Given: Consent is cleared and app relaunched for auto-display
+        print("🧪 Test 3: Widget Close Button")
+
+        helper.launchApp()
+        sleep(2)
+
+        // Clear existing consent
+        print("  Clearing consent...")
+        helper.tapClearConsentButton(timeout: 3.0)
+        sleep(1)
+
+        // Terminate and relaunch for auto-display
+        app.terminate()
+        sleep(2)
+
+        helper.launchApp()
+        sleep(2)
+
+        XCTAssertTrue(helper.isWidgetDisplayed(), "Widget should auto-display")
+
+        // When: User taps close/dismiss button (if available)
+        let webView = app.webViews.firstMatch
+        let closeButton = webView.buttons.containing(NSPredicate(format: "label CONTAINS[c] 'close' OR label CONTAINS[c] 'fermer' OR label == 'X'")).firstMatch
+
+        if closeButton.exists {
+            closeButton.tap()
+            sleep(5)
+
+            // Then: Widget should disappear
+            let widgetDismissed = !helper.isWidgetDisplayed(timeout: 5.0)
+            XCTAssertTrue(widgetDismissed, "Widget should disappear after closing")
+
+            print("✅ Test 3 Passed: Widget close button works")
+        } else {
+            print("⚠️ Test 3 Skipped: Close button not available in this widget configuration")
+        }
+    }
+
+    // MARK: - Test 4: Accept Consent Persists Event
+
+    func testAcceptConsentTriggersEvent() throws {
+        // Given: Consent is cleared and app relaunched for auto-display
+        print("🧪 Test 4: Accept Consent Triggers Event")
+
+        helper.launchApp()
+        sleep(2)
+
+        // Clear existing consent
+        print("  Clearing consent...")
+        helper.tapClearConsentButton(timeout: 3.0)
+        sleep(1)
+
+        // Terminate and relaunch for auto-display
+        app.terminate()
+        sleep(2)
+
+        helper.launchApp()
+        sleep(2)
+
+        XCTAssertTrue(helper.isWidgetDisplayed(), "Widget should auto-display")
+
+        // When: User accepts consent
+        let acceptTapped = helper.tapAcceptButton(timeout: 5.0)
+        XCTAssertTrue(acceptTapped, "Accept button should be tapped")
+
+        // Wait for consent to be processed
+        sleep(5)
+
+        // Then: Consent event should fire (verified by widget dismissal and app state)
+        // In a real scenario, you might check:
+        // - Network requests were made (using Xcode network debugging)
+        // - UserDefaults were updated (requires app exposure)
+        // - Analytics events were triggered
+
+        let widgetDismissed = !helper.isWidgetDisplayed(timeout: 5.0)
+        XCTAssertTrue(widgetDismissed, "Widget should be dismissed indicating consent was processed")
+
+        // Take final screenshot
+        let screenshot = helper.takeScreenshot(named: "Test4_ConsentEventProcessed")
+        add(screenshot)
+
+        print("✅ Test 4 Passed: Consent event appears to have been processed")
+    }
+
+    // MARK: - Test 5: Multiple Consent Actions
+
+    func testMultipleConsentActions() throws {
+        // Given: Consent is cleared and app relaunched for auto-display
+        print("🧪 Test 5: Multiple Consent Actions Handling")
+
+        helper.launchApp()
+        sleep(2)
+
+        // Clear existing consent
+        print("  Clearing consent...")
+        helper.tapClearConsentButton(timeout: 3.0)
+        sleep(1)
+
+        // Terminate and relaunch for auto-display
+        app.terminate()
+        sleep(2)
+
+        helper.launchApp()
+        sleep(2)
+
+        XCTAssertTrue(helper.isWidgetDisplayed(), "Widget should auto-display")
+
+        // When: User taps accept button multiple times rapidly
+        let webView = app.webViews.firstMatch
+        let acceptButton = webView.buttons.containing(NSPredicate(format: "label CONTAINS[c] 'accept'")).firstMatch
+
+        if acceptButton.exists {
+            acceptButton.tap()
+            acceptButton.tap() // Second tap (if widget hasn't dismissed yet)
+            sleep(5)
+
+            // Then: Widget should handle multiple taps gracefully (no crash)
+            // The test passing means the app didn't crash
+            print("✅ Test 5 Passed: Multiple consent actions handled gracefully")
+        } else {
+            print("⚠️ Test 5 Skipped: Accept button not found")
+        }
+    }
+}

--- a/sampleSwift/sampleSwiftUITests/Test3_PersistenceTests.swift
+++ b/sampleSwift/sampleSwiftUITests/Test3_PersistenceTests.swift
@@ -1,0 +1,372 @@
+//
+//  Test3_PersistenceTests.swift
+//  AxeptioSDK Integration Tests
+//
+//  Test Scenario 3: Consent Persistence Verification
+//  Validates that consent choices persist across app restarts and consent duration is respected
+//
+//  CRITICAL: These tests validate fixes for:
+//  - MSK-136: Consent duration persistence (190 days default)
+//  - MSK-139: ATT + consent persistence when allowPopupDisplayWithRejectedDeviceTrackingPermissions = true
+//
+//  Created by Claude Sonnet 4.5 on 29/12/2024.
+//  MSK-140: XCUITest-based integration tests
+//
+
+import XCTest
+
+class Test3_PersistenceTests: XCTestCase {
+
+    var app: XCUIApplication!
+    var helper: AxeptioIntegrationTestsHelper!
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+
+        // Lock device to portrait orientation
+        XCUIDevice.shared.orientation = .portrait
+
+        app = XCUIApplication()
+        helper = AxeptioIntegrationTestsHelper(app: app)
+    }
+
+    override func tearDownWithError() throws {
+        app.terminate()
+        app = nil
+        helper = nil
+    }
+
+    // MARK: - Test 1: Consent Persists Across App Restarts
+
+    func testConsentPersistsAcrossAppRestarts() throws {
+        // Given: App is launched for the first time
+        print("🧪 Test 1: Consent Persists Across App Restarts")
+        print("  This test validates MSK-136 and MSK-139 fixes")
+
+        // FIRST LAUNCH: Clear consent and relaunch for auto-display
+        print("  [Setup] Launching app to clear consent...")
+        helper.launchApp()
+        sleep(2)
+
+        // Clear any existing consent to ensure clean state
+        print("  [Setup] Clearing existing consent...")
+        helper.tapClearConsentButton(timeout: 3.0)
+        sleep(1)
+
+        // Terminate and relaunch for auto-display
+        print("  [Setup] Terminating app...")
+        app.terminate()
+        sleep(2)
+
+        print("  [Launch 1] Relaunching app for widget auto-display...")
+        helper.launchApp()
+        sleep(2)
+
+        // Verify widget auto-displays
+        XCTAssertTrue(helper.isWidgetDisplayed(timeout: 5.0), "Widget should auto-display after consent cleared")
+
+        // Take screenshot before acceptance
+        let beforeScreenshot = helper.takeScreenshot(named: "Test3_Persistence_Launch1_Before")
+        add(beforeScreenshot)
+
+        // Accept consent
+        print("  [Launch 1] Accepting consent...")
+        let acceptTapped = helper.tapAcceptButton(timeout: 5.0)
+        XCTAssertTrue(acceptTapped, "Accept button should be found and tapped")
+
+        // Wait for consent to be processed
+        sleep(3)
+
+        // Verify widget dismissed after acceptance
+        let widgetDismissed = !helper.isWidgetDisplayed(timeout: 2.0)
+        XCTAssertTrue(widgetDismissed, "Widget should be dismissed after accepting consent")
+
+        // Take screenshot after acceptance
+        let afterScreenshot = helper.takeScreenshot(named: "Test3_Persistence_Launch1_After")
+        add(afterScreenshot)
+
+        print("  [Launch 1] Consent accepted, widget dismissed")
+
+        // TERMINATE APP
+        print("  Terminating app...")
+        app.terminate()
+        sleep(2)
+
+        // SECOND LAUNCH: Verify consent persisted
+        print("  [Launch 2] Relaunching app...")
+        helper.launchApp()
+        sleep(3) // Give extra time for initialization
+
+        // Then: Widget should NOT be displayed (consent already given)
+        let widgetRedisplayed = helper.isWidgetDisplayed(timeout: 3.0)
+        XCTAssertFalse(widgetRedisplayed, "Widget should NOT be displayed on second launch (consent persisted)")
+
+        // Take screenshot to verify
+        let secondLaunchScreenshot = helper.takeScreenshot(named: "Test3_Persistence_Launch2_NoWidget")
+        add(secondLaunchScreenshot)
+
+        if widgetRedisplayed {
+            print("  ❌ FAIL: Widget was displayed on second launch - consent did NOT persist")
+            print("  This indicates a regression in MSK-136 or MSK-139 fix")
+        } else {
+            print("  ✅ PASS: Widget not displayed on second launch - consent persisted correctly")
+        }
+    }
+
+    // MARK: - Test 2: Multiple App Restarts Maintain Consent
+
+    func testMultipleAppRestartsMaintainConsent() throws {
+        // Given: Accept consent first to set up initial state
+        print("🧪 Test 2: Multiple App Restarts Maintain Consent")
+
+        // FIRST LAUNCH: Clear consent and relaunch for auto-display
+        print("  [Initial Setup] Launching app to clear consent...")
+        helper.launchApp()
+        sleep(2)
+
+        // Clear any existing consent
+        print("  [Initial Setup] Clearing consent...")
+        helper.tapClearConsentButton(timeout: 3.0)
+        sleep(1)
+
+        // Terminate and relaunch for auto-display
+        app.terminate()
+        sleep(2)
+
+        helper.launchApp()
+        sleep(2)
+
+        // Verify widget auto-displays and accept
+        XCTAssertTrue(helper.isWidgetDisplayed(timeout: 5.0), "Widget should auto-display")
+        helper.tapAcceptButton(timeout: 5.0)
+        sleep(3)
+
+        // Terminate app
+        app.terminate()
+        sleep(2)
+
+        // MULTIPLE RESTARTS: Verify consent persists
+        for i in 1...3 {
+            print("  [Restart \(i)] Launching app...")
+            helper.launchApp()
+            sleep(2)
+
+            // Widget should not appear (consent already given)
+            let widgetDisplayed = helper.isWidgetDisplayed(timeout: 3.0)
+            XCTAssertFalse(widgetDisplayed, "Widget should not appear on restart #\(i)")
+
+            // Take screenshot
+            let screenshot = helper.takeScreenshot(named: "Test3_MultipleRestarts_Launch\(i)")
+            add(screenshot)
+
+            // Terminate
+            app.terminate()
+            sleep(1)
+        }
+
+        print("  ✅ Test 2 Passed: Consent persisted across \(3) restarts")
+    }
+
+    // MARK: - Test 3: Consent Duration End Date Persistence
+
+    func testConsentDurationEndDatePersistence() throws {
+        // Given: App is launched and consent is accepted
+        print("🧪 Test 3: Consent Duration End Date Persistence")
+        print("  Validates MSK-136: 190-day consent duration is stored")
+
+        helper.launchApp()
+        sleep(2)
+
+        // Clear existing consent
+        print("  Clearing consent...")
+        helper.tapClearConsentButton(timeout: 3.0)
+        sleep(1)
+
+        // Terminate and relaunch for auto-display
+        app.terminate()
+        sleep(2)
+
+        helper.launchApp()
+        sleep(2)
+
+        // Verify widget auto-displays
+        XCTAssertTrue(helper.isWidgetDisplayed(timeout: 5.0), "Widget should auto-display")
+
+        // Accept consent
+        print("  Accepting consent...")
+        helper.tapAcceptButton(timeout: 5.0)
+        sleep(3)
+
+        // Then: UserDefaults should contain consent duration end date
+        // Note: Direct UserDefaults verification from UI tests is limited
+        // This test validates that consent persists, implying the date was stored
+
+        // Relaunch to verify persistence
+        helper.relaunchApp()
+        sleep(2)
+
+        let widgetRedisplayed = helper.isWidgetDisplayed(timeout: 3.0)
+        XCTAssertFalse(widgetRedisplayed, "Widget should not redisplay (implies duration end date was stored)")
+
+        // Take screenshot
+        let screenshot = helper.takeScreenshot(named: "Test3_DurationPersistence_Verified")
+        add(screenshot)
+
+        print("  ✅ Test 3 Passed: Consent duration appears to be persisted")
+    }
+
+    // MARK: - Test 4: App Backgrounding Doesn't Clear Consent
+
+    func testAppBackgroundingDoesntClearConsent() throws {
+        // Given: App is launched with consent accepted
+        print("🧪 Test 4: App Backgrounding Doesn't Clear Consent")
+
+        helper.launchApp()
+        sleep(2)
+
+        // Clear existing consent
+        print("  Clearing consent...")
+        helper.tapClearConsentButton(timeout: 3.0)
+        sleep(1)
+
+        // Terminate and relaunch for auto-display
+        app.terminate()
+        sleep(2)
+
+        helper.launchApp()
+        sleep(2)
+
+        // Verify widget auto-displays
+        XCTAssertTrue(helper.isWidgetDisplayed(timeout: 5.0), "Widget should auto-display")
+
+        // Accept consent
+        print("  Accepting consent...")
+        helper.tapAcceptButton(timeout: 5.0)
+        sleep(3)
+
+        // Widget should be dismissed
+        XCTAssertFalse(helper.isWidgetDisplayed(timeout: 2.0), "Widget should be dismissed")
+
+        // When: App is backgrounded and foregrounded multiple times
+        for i in 1...3 {
+            print("  [Background cycle \(i)]")
+            XCUIDevice.shared.press(.home)
+            sleep(1)
+            app.activate()
+            sleep(1)
+
+            // Then: Widget should still not reappear
+            let widgetReappeared = helper.isWidgetDisplayed(timeout: 2.0)
+            XCTAssertFalse(widgetReappeared, "Widget should not reappear after backgrounding #\(i)")
+        }
+
+        print("  ✅ Test 4 Passed: Consent persisted through backgrounding cycles")
+    }
+
+    // MARK: - Test 5: Consent State After App Termination from Background
+
+    func testConsentStateAfterTerminationFromBackground() throws {
+        // Given: App is launched with consent accepted
+        print("🧪 Test 5: Consent State After Termination from Background")
+
+        helper.launchApp()
+        sleep(2)
+
+        // Clear existing consent
+        print("  Clearing consent...")
+        helper.tapClearConsentButton(timeout: 3.0)
+        sleep(1)
+
+        // Terminate and relaunch for auto-display
+        app.terminate()
+        sleep(2)
+
+        helper.launchApp()
+        sleep(2)
+
+        // Verify widget auto-displays
+        XCTAssertTrue(helper.isWidgetDisplayed(timeout: 5.0), "Widget should auto-display")
+
+        // Accept consent
+        print("  Accepting consent...")
+        helper.tapAcceptButton(timeout: 5.0)
+        sleep(3)
+
+        // Widget should be dismissed
+        XCTAssertFalse(helper.isWidgetDisplayed(timeout: 2.0), "Widget should be dismissed")
+
+        // When: App is sent to background, then force-terminated
+        XCUIDevice.shared.press(.home)
+        sleep(1)
+        app.terminate()
+        sleep(2)
+
+        // Relaunch
+        print("  Relaunching after background termination...")
+        helper.launchApp()
+        sleep(3)
+
+        // Then: Widget should still not appear
+        let widgetRedisplayed = helper.isWidgetDisplayed(timeout: 3.0)
+        XCTAssertFalse(widgetRedisplayed, "Widget should not reappear after background termination")
+
+        // Take screenshot
+        let screenshot = helper.takeScreenshot(named: "Test5_BackgroundTermination_NoWidget")
+        add(screenshot)
+
+        print("  ✅ Test 5 Passed: Consent persisted after background termination")
+    }
+
+    // MARK: - Test 6: Consent Persists After System Reboot Simulation
+
+    func testConsentPersistsAfterDelayedRelaunch() throws {
+        // Given: App is launched with consent accepted
+        print("🧪 Test 6: Consent Persists After Delayed Relaunch")
+        print("  Simulates system reboot or long-term storage")
+
+        helper.launchApp()
+        sleep(2)
+
+        // Clear existing consent
+        print("  Clearing consent...")
+        helper.tapClearConsentButton(timeout: 3.0)
+        sleep(1)
+
+        // Terminate and relaunch for auto-display
+        app.terminate()
+        sleep(2)
+
+        helper.launchApp()
+        sleep(2)
+
+        // Verify widget auto-displays
+        XCTAssertTrue(helper.isWidgetDisplayed(timeout: 5.0), "Widget should auto-display")
+
+        // Accept consent
+        print("  Accepting consent...")
+        helper.tapAcceptButton(timeout: 5.0)
+        sleep(3)
+
+        // Terminate app
+        app.terminate()
+
+        // Wait longer (simulating device restart or long time between launches)
+        print("  Waiting 10 seconds to simulate delayed relaunch...")
+        sleep(10)
+
+        // Relaunch
+        print("  Relaunching after delay...")
+        helper.launchApp()
+        sleep(3)
+
+        // Then: Widget should still not appear
+        let widgetRedisplayed = helper.isWidgetDisplayed(timeout: 3.0)
+        XCTAssertFalse(widgetRedisplayed, "Widget should not reappear after delayed relaunch")
+
+        // Take screenshot
+        let screenshot = helper.takeScreenshot(named: "Test6_DelayedRelaunch_NoWidget")
+        add(screenshot)
+
+        print("  ✅ Test 6 Passed: Consent persisted after delayed relaunch")
+    }
+}

--- a/sampleSwift/sampleSwiftUITests/Test4_RowJScenarioTests.swift
+++ b/sampleSwift/sampleSwiftUITests/Test4_RowJScenarioTests.swift
@@ -111,13 +111,14 @@ class Test4_RowJScenarioTests: XCTestCase {
         // and no crash/freeze occurs. Actual consent submission verification requires
         // either network monitoring or backend integration.
 
-        // When: User accepts consent
-        print("  Simulating user consent action...")
-        // Note: Actual button interaction depends on widget configuration
-        // This is a placeholder for future implementation when we can interact with webview buttons
-
-        print("⚠️  Test 4.2: Partial verification only - full test requires webview button interaction")
-        print("✅ Test 4.2: Widget displayed without auto-sending consent")
+        // The defining assertion of this test — that consent is NOT transmitted before the
+        // user acts — cannot be made from a UI test: it needs network interception or
+        // backend verification. Reporting a pass here would claim Row J coverage the suite
+        // does not actually have, so skip explicitly once the verifiable part is done.
+        throw XCTSkip(
+            "Partial verification only: widget displayed without crash, but 'no automatic "
+            + "consent submission' requires network or backend verification."
+        )
     }
 
     // MARK: - Row J Manual Display: Button Click Should Work

--- a/sampleSwift/sampleSwiftUITests/Test4_RowJScenarioTests.swift
+++ b/sampleSwift/sampleSwiftUITests/Test4_RowJScenarioTests.swift
@@ -1,0 +1,171 @@
+//
+//  Test4_RowJScenarioTests.swift
+//  AxeptioSDK Integration Tests
+//
+//  Test Scenario 4: Row J Scenario (MSK-142 Fix)
+//  Validates widget auto-display when ATT denied + flag enabled + no consent
+//
+//  Created by Claude Code on 2025-12-31.
+//  MSK-142: Row J bug fix validation
+//
+//  IMPORTANT: Full Row J testing requires:
+//  1. Device/simulator with ATT status = .denied
+//  2. allowPopupDisplayWithRejectedDeviceTrackingPermissions = true in config
+//  3. No existing consent data
+//
+//  This test validates the core behavior (auto-display with no consent).
+//  Manual testing required to verify the complete Row J scenario with actual ATT denial.
+//
+
+import XCTest
+
+class Test4_RowJScenarioTests: XCTestCase {
+
+    var app: XCUIApplication!
+    var helper: AxeptioIntegrationTestsHelper!
+
+    override func setUpWithError() throws {
+        // Stop immediately when a failure occurs
+        continueAfterFailure = false
+
+        // Lock device to portrait orientation
+        XCUIDevice.shared.orientation = .portrait
+
+        // Initialize app
+        app = XCUIApplication()
+        helper = AxeptioIntegrationTestsHelper(app: app)
+    }
+
+    override func tearDownWithError() throws {
+        // Terminate app after each test
+        app.terminate()
+        app = nil
+        helper = nil
+    }
+
+    // MARK: - Row J Core Behavior: Auto-Display with No Consent
+
+    func testRowJ_AutoDisplayWithNoConsent() throws {
+        // Test validates the core Row J behavior: auto-display when no consent exists
+        // Full Row J scenario (ATT denied + flag enabled) requires manual testing
+        print("🧪 Test 4.1: Row J - Auto-Display with No Consent")
+
+        // Given: App launches and consent is cleared
+        print("  Launching app...")
+        helper.launchApp()
+        sleep(2)
+
+        // Clear existing consent to simulate "no consent" state
+        print("  Clearing consent...")
+        helper.tapClearConsentButton(timeout: 3.0)
+        sleep(1)
+
+        // Terminate to reset state
+        print("  Terminating app...")
+        app.terminate()
+        sleep(2)
+
+        // When: App relaunches with no consent
+        print("  Relaunching app with no consent...")
+        helper.launchApp()
+        sleep(2)
+
+        // Then: Widget should auto-display (Row J behavior)
+        let widgetDisplayed = helper.isWidgetDisplayed(timeout: 5.0)
+        XCTAssertTrue(widgetDisplayed, "Widget should auto-display when no consent exists (Row J core behavior)")
+
+        // Take screenshot for visual verification
+        let screenshot = helper.takeScreenshot(named: "Test4_RowJ_AutoDisplay_NoConsent")
+        add(screenshot)
+
+        print("✅ Test 4.1 Passed: Widget auto-displayed with no consent")
+    }
+
+    // MARK: - Row J User Interaction: Consent Sent Only on User Action
+
+    func testRowJ_ConsentSentOnUserActionOnly() throws {
+        // Validates that consent is NOT auto-sent, only sent after user action
+        print("🧪 Test 4.2: Row J - Consent Sent Only on User Action")
+
+        // Given: App launches with no consent
+        helper.launchApp()
+        sleep(2)
+
+        helper.tapClearConsentButton(timeout: 3.0)
+        sleep(1)
+
+        app.terminate()
+        sleep(2)
+
+        helper.launchApp()
+        sleep(2)
+
+        // Verify widget displays
+        XCTAssertTrue(helper.isWidgetDisplayed(timeout: 5.0), "Widget should auto-display")
+
+        // Wait a few seconds to ensure NO automatic consent submission occurs
+        print("  Waiting to verify no automatic consent submission...")
+        sleep(3)
+
+        // Note: Without backend verification, we can only verify the widget is displayed
+        // and no crash/freeze occurs. Actual consent submission verification requires
+        // either network monitoring or backend integration.
+
+        // When: User accepts consent
+        print("  Simulating user consent action...")
+        // Note: Actual button interaction depends on widget configuration
+        // This is a placeholder for future implementation when we can interact with webview buttons
+
+        print("⚠️  Test 4.2: Partial verification only - full test requires webview button interaction")
+        print("✅ Test 4.2: Widget displayed without auto-sending consent")
+    }
+
+    // MARK: - Row J Manual Display: Button Click Should Work
+
+    func testRowJ_ManualDisplayWorks() throws {
+        // Validates that manual "Display Consent" button works in Row J scenario
+        print("🧪 Test 4.3: Row J - Manual Display Works")
+
+        // Given: App launches with consent cleared
+        helper.launchApp()
+        sleep(2)
+
+        helper.tapClearConsentButton(timeout: 3.0)
+        sleep(1)
+
+        // When: User taps "Display Consent" button manually
+        print("  Tapping Display Consent button...")
+        helper.tapShowConsentButton(timeout: 3.0)
+        sleep(2)
+
+        // Then: Widget should display
+        let widgetDisplayed = helper.isWidgetDisplayed(timeout: 5.0)
+        XCTAssertTrue(widgetDisplayed, "Widget should display when triggered manually in Row J scenario")
+
+        // Take screenshot
+        let screenshot = helper.takeScreenshot(named: "Test4_RowJ_ManualDisplay")
+        add(screenshot)
+
+        print("✅ Test 4.3 Passed: Manual display works in Row J scenario")
+    }
+
+    // MARK: - Documentation Test: Full Row J Manual Testing Instructions
+
+    func testRowJ_ManualTestingInstructions() throws {
+        // This test provides instructions for complete Row J manual validation
+        print("📋 Row J Manual Testing Instructions:")
+        print("   1. Configure device/simulator with ATT tracking authorization = .denied")
+        print("   2. In sample app, enable 'Allow Popup With Rejected ATT' toggle")
+        print("   3. Clear all consent data")
+        print("   4. Force quit and relaunch app")
+        print("   5. VERIFY: Widget auto-displays on launch")
+        print("   6. VERIFY: Consent is NOT automatically sent")
+        print("   7. VERIFY: Consent is sent only after user accepts/rejects")
+        print("")
+        print("   Full Row J scenario cannot be automated due to ATT system limitations.")
+        print("   These integration tests validate core behavior components.")
+
+        // Always pass - this is documentation
+        XCTAssertTrue(true, "Manual testing instructions provided")
+    }
+}

--- a/sampleSwift/sampleSwiftUITests/sampleSwiftUITests.swift
+++ b/sampleSwift/sampleSwiftUITests/sampleSwiftUITests.swift
@@ -1,0 +1,41 @@
+//
+//  sampleSwiftUITests.swift
+//  sampleSwiftUITests
+//
+//  Created by Philippe Le Berre on 29.12.2025.
+//
+
+import XCTest
+
+final class sampleSwiftUITests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+
+        // In UI tests it is usually best to stop immediately when a failure occurs.
+        continueAfterFailure = false
+
+        // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    @MainActor
+    func testExample() throws {
+        // UI tests must launch the application that they test.
+        let app = XCUIApplication()
+        app.launch()
+
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    }
+
+    @MainActor
+    func testLaunchPerformance() throws {
+        // This measures how long it takes to launch your application.
+        measure(metrics: [XCTApplicationLaunchMetric()]) {
+            XCUIApplication().launch()
+        }
+    }
+}

--- a/sampleSwift/sampleSwiftUITests/sampleSwiftUITests.swift
+++ b/sampleSwift/sampleSwiftUITests/sampleSwiftUITests.swift
@@ -33,6 +33,14 @@ final class sampleSwiftUITests: XCTestCase {
 
     @MainActor
     func testLaunchPerformance() throws {
+        // measure() runs several launch iterations, which is meaningful cost on a suite that
+        // already takes ~30 minutes against the live consent widget. Opt in explicitly when
+        // launch performance is what you are actually investigating.
+        try XCTSkipUnless(
+            ProcessInfo.processInfo.environment["AXEPTIO_RUN_PERF_TESTS"] == "1",
+            "Set AXEPTIO_RUN_PERF_TESTS=1 to run launch performance measurements."
+        )
+
         // This measures how long it takes to launch your application.
         measure(metrics: [XCTApplicationLaunchMetric()]) {
             XCUIApplication().launch()

--- a/sampleSwift/sampleSwiftUITests/sampleSwiftUITestsLaunchTests.swift
+++ b/sampleSwift/sampleSwiftUITests/sampleSwiftUITestsLaunchTests.swift
@@ -1,0 +1,33 @@
+//
+//  sampleSwiftUITestsLaunchTests.swift
+//  sampleSwiftUITests
+//
+//  Created by Philippe Le Berre on 29.12.2025.
+//
+
+import XCTest
+
+final class sampleSwiftUITestsLaunchTests: XCTestCase {
+
+    override class var runsForEachTargetApplicationUIConfiguration: Bool {
+        true
+    }
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    @MainActor
+    func testLaunch() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        // Insert steps here to perform after app launch but before taking a screenshot,
+        // such as logging into a test account or navigating somewhere in the app
+
+        let attachment = XCTAttachment(screenshot: app.screenshot())
+        attachment.name = "Launch Screen"
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+}


### PR DESCRIPTION
## Summary

Phase 2 of syncing `sample-app-ios` with the upstream sample: ports the XCUITest suite and adds CI to run it.

- **Test suite** (`sampleSwift/sampleSwiftUITests/`, 8 files / 25 tests): diagnostic, widget display, consent flow, persistence, Row J scenario + a tolerant helper. Ported from `axeptio-ios-sdk-sources`, verified clean of AAP / 2.3.0 deps.
- **Project wiring**: added a `sampleSwiftUITests` UI-testing target via the `xcodeproj` gem (`TEST_TARGET_NAME=sampleSwift`, bundle id `io.axeptio.sampleSwiftUITests`, iOS 18.0 / Swift 5.0) and repointed the shared `sampleSwift` scheme's TestAction from orphan references to the real target. Project stays `objectVersion 56`.
- **CI** (`.github/workflows/ui-tests.yml`): runs `xcodebuild test` **inline** (this repo is public and cannot call Axeptio internal/private reusable workflows). Triggers **nightly + `workflow_dispatch`**, not per-PR — the suite drives the live consent webview over the network and takes ~30 min, too slow/flaky to gate PRs. `GITHUB_TOKEN` restricted to `contents: read` (CodeQL finding).

## Fixes made while porting

- `Test4` called a non-existent helper method `tapDisplayConsentButton` → `tapShowConsentButton` (pre-existing upstream defect; never surfaced because upstream CI only tests the `AxeptioSDK` scheme).
- `tapClearConsentButton` logged every button label via `allElementsBoundByIndex.map { $0.label }`, taking a per-element accessibility snapshot that throws `No matches found for Element at index N` once the webview is on screen — caused 10 of 17 initial CI failures. Now logs the button count.

## CI result

Latest nightly-equivalent run: **23 / 25 passing** (`-retry-tests-on-failure` enabled). The 2 remaining are network/timing-bound and tracked in a follow-up:
- `testWidgetLoadsWithinAcceptableTime` — widget loaded in ~17s vs a 10s threshold (CI runner + CDN latency).
- `testMultipleConsentActions` — a "Close without accepting cookies" button not present in the live widget content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)