### PR TITLE
chore(build): add swiftlint config and make the lint gate pass

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,4 @@
-npm run build:check
+# Lint and build. Deliberately NOT `npm run pre-commit`: that also chains test:check,
+# which is the network-bound XCUITest suite (~30 min against the live consent widget) and
+# has no business in a commit hook. The suite runs nightly via .github/workflows/ui-tests.yml.
+npm run lint:check && npm run build:check

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,37 @@
+# SwiftLint configuration for the Axeptio iOS sample app.
+#
+# Before this file existed, `npm run lint` ran on stock defaults and reported 23 errors under
+# --strict, so it could never be used as a gate. Most were rule-vs-convention conflicts rather
+# than defects; those are configured here, and the genuine ones were fixed.
+
+included:
+  - sampleSwift
+
+excluded:
+  - sampleSwift/build
+  - sampleSwift/sampleSwift.xcodeproj
+
+type_name:
+  # The XCUITest suites are deliberately named Test0_DiagnosticTest … Test5_ReopenConsentTests.
+  # The numeric prefix gives them a run order in reports and makes `-only-testing:` invocations
+  # readable, and those names appear in CI docs and workflow arguments. Renaming six suites to
+  # satisfy a style rule would break those references for no readability gain, so underscores
+  # are permitted instead.
+  allowed_symbols: ["_"]
+  # Xcode-generated, named after the target, which is itself lowercase. Renaming them means
+  # renaming the target. Listed by name rather than relaxing
+  # `validates_start_with_lowercase` globally, so a genuinely lowercase new type still fails.
+  excluded:
+    - sampleSwiftUITests
+    - sampleSwiftUITestsLaunchTests
+
+identifier_name:
+  # Standard Swift shorthand for coordinates and generic indices. Loop counters that carry real
+  # meaning are still expected to say what they mean — the two `for i in 1...3` loops that
+  # triggered this rule were renamed rather than exempted.
+  excluded:
+    - x
+    - y
+    - z
+    - id
+    - to

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,7 +106,11 @@ npm run release
 
 ## Pre-commit Validation
 
-`.husky/pre-commit` runs `npm run build:check` — an Xcode build of the sample app. Note this does **not** currently run SwiftLint or tests, despite `npm run pre-commit` being defined to do so. `.husky/commit-msg` validates the commit message format via commitlint.
+`.husky/pre-commit` runs `npm run lint:check && npm run build:check` — SwiftLint (`--strict`, configured by `.swiftlint.yml`) followed by an Xcode build. Both degrade to a skip message when the tool is absent, so the hook still works without Xcode or SwiftLint installed.
+
+It deliberately does **not** run `npm run pre-commit`, even though that script exists: that chains `test:check`, which is the XCUITest suite — ~30 minutes against the live consent widget over the network. That suite runs nightly via `.github/workflows/ui-tests.yml`, not on every commit.
+
+`.husky/commit-msg` validates the commit message format via commitlint.
 
 ## Version Synchronization
 

--- a/sampleSwift/sampleSwift/ConfigurationManager.swift
+++ b/sampleSwift/sampleSwift/ConfigurationManager.swift
@@ -132,7 +132,8 @@ class ConfigurationManager {
     var currentConfiguration: CustomerConfiguration {
         get {
             let clientId = userDefaults.string(forKey: Keys.clientId) ?? "5fbfa806a0787d3985c6ee5f"
-            let cookiesVersion = userDefaults.string(forKey: Keys.cookiesVersion) ?? "google cmp partner program sandbox-en-EU"
+            let cookiesVersion = userDefaults.string(forKey: Keys.cookiesVersion)
+                ?? "google cmp partner program sandbox-en-EU"
             let token = userDefaults.string(forKey: Keys.token)
             let cookiesDuration = userDefaults.object(forKey: Keys.cookiesDuration) as? Int ?? 190
             let shouldUpdateCookiesDuration = userDefaults.bool(forKey: Keys.shouldUpdateCookiesDuration)

--- a/sampleSwift/sampleSwift/View/ConfigurationViewController.swift
+++ b/sampleSwift/sampleSwift/View/ConfigurationViewController.swift
@@ -73,7 +73,8 @@ class ConfigurationViewController: UIViewController {
         setupPresetConfigurationSection()
 
         // Add observers for text field changes
-        [clientIdTextField, cookiesVersionTextField, tokenTextField, cookiesDurationTextfield, widgetPRTextField].forEach { textField in
+        [clientIdTextField, cookiesVersionTextField, tokenTextField,
+         cookiesDurationTextfield, widgetPRTextField].forEach { textField in
             textField.addTarget(self, action: #selector(textFieldDidChange), for: .editingChanged)
         }
         widgetTypeSegmentedControl.addTarget(self, action: #selector(segmentedControlChanged), for: .valueChanged)
@@ -132,7 +133,9 @@ class ConfigurationViewController: UIViewController {
         presetTableView.layer.cornerRadius = 8
         presetTableView.layer.borderWidth = 1
         presetTableView.layer.borderColor = UIColor.systemGray4.cgColor
-        presetTableView.heightAnchor.constraint(equalToConstant: CGFloat(presetConfigurations.count * 44)).isActive = true
+        presetTableView.heightAnchor
+            .constraint(equalToConstant: CGFloat(presetConfigurations.count * 44))
+            .isActive = true
 
         stackView.addArrangedSubview(presetTableView)
 

--- a/sampleSwift/sampleSwift/View/ConsentDebugViewController.swift
+++ b/sampleSwift/sampleSwift/View/ConsentDebugViewController.swift
@@ -66,7 +66,10 @@ extension ConsentDebugViewController: UITableViewDataSource, UITableViewDelegate
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        guard let cell = tableView.dequeueReusableCell(withIdentifier: "ConsentDebugCell", for: indexPath) as? ConsentDebugCell else {
+        guard let cell = tableView.dequeueReusableCell(
+            withIdentifier: "ConsentDebugCell",
+            for: indexPath
+        ) as? ConsentDebugCell else {
             return UITableViewCell()
         }
 

--- a/sampleSwift/sampleSwift/View/UserDefaultsViewController.swift
+++ b/sampleSwift/sampleSwift/View/UserDefaultsViewController.swift
@@ -37,7 +37,10 @@ extension UserDefaultsViewController: UITableViewDataSource {
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        guard let cell = tableView.dequeueReusableCell(withIdentifier: "UserDefaultsCell", for: indexPath) as? UserDefaultsCell else {
+        guard let cell = tableView.dequeueReusableCell(
+            withIdentifier: "UserDefaultsCell",
+            for: indexPath
+        ) as? UserDefaultsCell else {
             return UITableViewCell()
         }
         cell.title?.text = Array(fields.keys)[indexPath.row]

--- a/sampleSwift/sampleSwift/View/VendorConsentViewController.swift
+++ b/sampleSwift/sampleSwift/View/VendorConsentViewController.swift
@@ -128,7 +128,8 @@ class VendorConsentViewController: UIViewController {
             let setBits = vendorConsents.filter { $0 == "1" }.count
             analysis += "• TCF String Set Bits: \(setBits)\n"
             if setBits != consentedVendors.count {
-                analysis += "• ⚠️ DISCREPANCY: API shows \(consentedVendors.count) consented, TCF string suggests \(setBits)\n"
+                analysis += "• ⚠️ DISCREPANCY: API shows \(consentedVendors.count) consented, "
+                    + "TCF string suggests \(setBits)\n"
             }
         }
 

--- a/sampleSwift/sampleSwiftUITests/AxeptioIntegrationTestsHelper.swift
+++ b/sampleSwift/sampleSwiftUITests/AxeptioIntegrationTestsHelper.swift
@@ -181,10 +181,15 @@ class AxeptioIntegrationTestsHelper {
             return true
         }
 
-        // Alternative: Look for specific consent button text
-        let acceptButton = app.buttons.containing(NSPredicate(format: "label CONTAINS[c] 'accept' OR label CONTAINS[c] 'accepter'")).firstMatch
-        if acceptButton.exists {
-            print("✅ Widget detected: Accept button found")
+        // Alternative: look for consent button text. Deliberately broad — this is a
+        // presence probe, not an action, so a dismiss control like "Close without accepting
+        // cookies" matching is fine and still proves the widget is up. Do not copy the
+        // stricter predicate from tapAcceptButton here.
+        let consentButton = app.buttons.containing(
+            NSPredicate(format: "label CONTAINS[c] 'accept' OR label CONTAINS[c] 'accepter'")
+        ).firstMatch
+        if consentButton.exists {
+            print("✅ Widget detected: consent button found")
             return true
         }
 

--- a/sampleSwift/sampleSwiftUITests/Test1_WidgetDisplayTests.swift
+++ b/sampleSwift/sampleSwiftUITests/Test1_WidgetDisplayTests.swift
@@ -100,13 +100,18 @@ class Test1_WidgetDisplayTests: XCTestCase {
         XCTAssertTrue(webView.exists, "WebView should exist in the widget")
 
         // Check for consent buttons inside the WebView (at least one should exist)
-        let hasAcceptButton = webView.buttons.containing(NSPredicate(format: "label CONTAINS[c] 'accept' OR label CONTAINS[c] 'tout accepter'")).firstMatch.exists
-        let hasRejectButton = webView.buttons.containing(NSPredicate(format: "label CONTAINS[c] 'reject' OR label CONTAINS[c] 'refus' OR label CONTAINS[c] 'deny'")).firstMatch.exists
+        let hasAcceptButton = webView.buttons.containing(
+            NSPredicate(format: "label CONTAINS[c] 'accept' OR label CONTAINS[c] 'tout accepter'")
+        ).firstMatch.exists
+        let hasRejectButton = webView.buttons.containing(
+            NSPredicate(format: "label CONTAINS[c] 'reject' OR label CONTAINS[c] 'refus' OR label CONTAINS[c] 'deny'")
+        ).firstMatch.exists
         let hasAnyButton = webView.buttons.count > 0
 
         XCTAssertTrue(
             hasAcceptButton || hasRejectButton || hasAnyButton,
-            "Widget should contain at least one action button (accept or reject). Found \(webView.buttons.count) buttons in WebView"
+            "Widget should contain at least one action button (accept or reject). "
+            + "Found \(webView.buttons.count) buttons in WebView"
         )
 
         // Take screenshot

--- a/sampleSwift/sampleSwiftUITests/Test2_ConsentFlowTests.swift
+++ b/sampleSwift/sampleSwiftUITests/Test2_ConsentFlowTests.swift
@@ -150,7 +150,9 @@ class Test2_ConsentFlowTests: XCTestCase {
 
         // When: User taps close/dismiss button (if available)
         let webView = app.webViews.firstMatch
-        let closeButton = webView.buttons.containing(NSPredicate(format: "label CONTAINS[c] 'close' OR label CONTAINS[c] 'fermer' OR label == 'X'")).firstMatch
+        let closeButton = webView.buttons.containing(
+            NSPredicate(format: "label CONTAINS[c] 'close' OR label CONTAINS[c] 'fermer' OR label == 'X'")
+        ).firstMatch
 
         if closeButton.exists {
             closeButton.tap()

--- a/sampleSwift/sampleSwiftUITests/Test3_PersistenceTests.swift
+++ b/sampleSwift/sampleSwiftUITests/Test3_PersistenceTests.swift
@@ -146,17 +146,17 @@ class Test3_PersistenceTests: XCTestCase {
         sleep(2)
 
         // MULTIPLE RESTARTS: Verify consent persists
-        for i in 1...3 {
-            print("  [Restart \(i)] Launching app...")
+        for restart in 1...3 {
+            print("  [Restart \(restart)] Launching app...")
             helper.launchApp()
             sleep(2)
 
             // Widget should not appear (consent already given)
             let widgetDisplayed = helper.isWidgetDisplayed(timeout: 3.0)
-            XCTAssertFalse(widgetDisplayed, "Widget should not appear on restart #\(i)")
+            XCTAssertFalse(widgetDisplayed, "Widget should not appear on restart #\(restart)")
 
             // Take screenshot
-            let screenshot = helper.takeScreenshot(named: "Test3_MultipleRestarts_Launch\(i)")
+            let screenshot = helper.takeScreenshot(named: "Test3_MultipleRestarts_Launch\(restart)")
             add(screenshot)
 
             // Terminate
@@ -248,8 +248,8 @@ class Test3_PersistenceTests: XCTestCase {
         XCTAssertFalse(helper.isWidgetDisplayed(timeout: 2.0), "Widget should be dismissed")
 
         // When: App is backgrounded and foregrounded multiple times
-        for i in 1...3 {
-            print("  [Background cycle \(i)]")
+        for cycle in 1...3 {
+            print("  [Background cycle \(cycle)]")
             XCUIDevice.shared.press(.home)
             sleep(1)
             app.activate()
@@ -257,7 +257,7 @@ class Test3_PersistenceTests: XCTestCase {
 
             // Then: Widget should still not reappear
             let widgetReappeared = helper.isWidgetDisplayed(timeout: 2.0)
-            XCTAssertFalse(widgetReappeared, "Widget should not reappear after backgrounding #\(i)")
+            XCTAssertFalse(widgetReappeared, "Widget should not reappear after backgrounding #\(cycle)")
         }
 
         print("  ✅ Test 4 Passed: Consent persisted through backgrounding cycles")

--- a/sampleSwift/sampleSwiftUITests/sampleSwiftUITests.swift
+++ b/sampleSwift/sampleSwiftUITests/sampleSwiftUITests.swift
@@ -15,7 +15,9 @@ final class sampleSwiftUITests: XCTestCase {
         // In UI tests it is usually best to stop immediately when a failure occurs.
         continueAfterFailure = false
 
-        // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
+        // In UI tests it’s important to set the initial state - such as interface
+        // orientation - required for your tests before they run. The setUp method is a
+        // good place to do this.
     }
 
     override func tearDownWithError() throws {

--- a/sampleSwift/sampleSwiftUITests/sampleSwiftUITestsLaunchTests.swift
+++ b/sampleSwift/sampleSwiftUITests/sampleSwiftUITestsLaunchTests.swift
@@ -9,6 +9,9 @@ import XCTest
 
 final class sampleSwiftUITestsLaunchTests: XCTestCase {
 
+    // Must stay `class`: this overrides an XCTestCase class property, and `static` cannot
+    // override. The rule does not account for `override`, so this is a false positive.
+    // swiftlint:disable:next static_over_final_class
     override class var runsForEachTargetApplicationUIConfiguration: Bool {
         true
     }


### PR DESCRIPTION
## Summary

`npm run lint` has never been usable as a gate. There is **no `.swiftlint.yml` in the repo at all**, so SwiftLint ran on stock defaults and reported 23 errors under `--strict` — which is why nothing ran it, despite `CONTRIBUTING.md` claiming the pre-commit hook did.

Now **0 violations in 20 files**, and the hook actually runs it.

> **Stacked on #48** — based on `feat/uitests-sync-2.4.0` because both touch `AxeptioIntegrationTestsHelper.swift`. Retarget to `develop` once #48 merges.

## Split by cause, not silenced wholesale

The 23 were a mix, and they deserve different treatment:

**Configured — rule vs. deliberate convention (8)**

- `type_name` `allowed_symbols: ["_"]` for `Test0_DiagnosticTest` … `Test5_ReopenConsentTests`. The numeric prefix orders them in reports and makes `-only-testing:` invocations readable, and those names appear in CI docs and workflow arguments. Renaming six suites to satisfy a style rule breaks the references for no readability gain.
- `type_name` `excluded` for `sampleSwiftUITests` / `sampleSwiftUITestsLaunchTests` — Xcode-generated, named after the target, so renaming them means renaming the target. Listed **by name** rather than relaxing `validates_start_with_lowercase` globally, so a genuinely lowercase new type still fails.

**Fixed properly — real issues (14)**

- 12 `line_length` violations wrapped, across app and test code.
- Two `for i in 1...3` loops renamed to `restart` and `cycle` — what they actually count. Exempting `i` in config was the alternative; the names are simply better.

**One targeted suppression (1)**

- `static_over_final_class` on `runsForEachTargetApplicationUIConfiguration`. It overrides an `XCTestCase` class property and `static` cannot override — a false positive, not a convention disagreement. Suppressed at the line with the reason, not globally.

## The hook now enforces it

`.husky/pre-commit` was `npm run build:check` only. It now runs `npm run lint:check && npm run build:check`.

It deliberately does **not** run `npm run pre-commit`, even though that script exists and CONTRIBUTING implied it should: that chains `test:check`, which is the XCUITest suite — ~30 minutes against the live consent widget over the network. That belongs in the nightly workflow, not a commit hook. `CONTRIBUTING.md` corrected to describe what actually runs.

Both checks degrade to a skip message when the tool is absent, so the hook still works without Xcode or SwiftLint installed.

## Test plan

- [x] `npm run lint` → `Done linting! Found 0 violations, 0 serious in 20 files.`
- [x] `TEST BUILD SUCCEEDED`
- [x] Smoke run: `testExample` passes; the four gated tests still report **skipped**
- [x] Pre-commit hook exercised on this very commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)