### PR TITLE
fix(build): resolve the simulator instead of pinning a device name

### DIFF
--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -21,7 +21,9 @@ concurrency:
 
 jobs:
   ui-tests:
-    name: XCUITest (iPhone 16)
+    # No device in the name: the runner's simulator set rotates, and the one actually used is
+    # logged by the Select a simulator step.
+    name: XCUITest
     runs-on: macos-latest
 
     steps:
@@ -37,13 +39,27 @@ jobs:
         working-directory: sampleSwift
         run: xcodebuild -resolvePackageDependencies -project sampleSwift.xcodeproj -scheme sampleSwift
 
+      # Resolve the device instead of naming it. Pinning 'iPhone 16' silently stopped working
+      # when GitHub rotated the runner image to the iPhone 17 family: every run failed in ~2
+      # minutes on destination resolution, before building anything.
+      - name: Select a simulator
+        id: sim
+        run: |
+          set -euo pipefail
+          # Fail the job here rather than handing xcodebuild an empty destination, which
+          # would produce a far less obvious error further down.
+          udid=$(scripts/pick-simulator.sh)
+          echo "udid=$udid" >> "$GITHUB_OUTPUT"
+
       - name: Run UI tests
         working-directory: sampleSwift
+        env:
+          SIM_UDID: ${{ steps.sim.outputs.udid }}
         run: |
           xcodebuild test \
             -project sampleSwift.xcodeproj \
             -scheme sampleSwift \
-            -destination 'platform=iOS Simulator,name=iPhone 16' \
+            -destination "id=$SIM_UDID" \
             -resultBundlePath TestResults.xcresult \
             -only-testing:sampleSwiftUITests \
             -retry-tests-on-failure \

--- a/.github/workflows/update-sdk-version.yml
+++ b/.github/workflows/update-sdk-version.yml
@@ -74,7 +74,9 @@ jobs:
       run: |
         echo "Building Swift sample app with updated SDK"
         cd sampleSwift
-        xcodebuild -project sampleSwift.xcodeproj -scheme sampleSwift -destination 'platform=iOS Simulator,name=iPhone 16' build
+        # Generic destination: this step only needs to prove the new SDK compiles and links,
+        # so it needs no concrete device — and cannot break when Apple rotates device names.
+        xcodebuild -project sampleSwift.xcodeproj -scheme sampleSwift -destination 'generic/platform=iOS Simulator' build
 
     - name: Check for changes
       id: changes

--- a/.gitignore
+++ b/.gitignore
@@ -217,3 +217,6 @@ dist
 
 # Build artifacts
 build.log
+
+# Beads local lock artifact (bd writes this; not repo content)
+.beads.gate.lock

--- a/package.json
+++ b/package.json
@@ -26,9 +26,9 @@
     "pre-commit": "npm run lint:check && npm run build:check && npm run test:check",
     "lint": "swiftlint --strict",
     "lint:check": "command -v swiftlint >/dev/null 2>&1 && npm run lint || echo 'SwiftLint not found, skipping lint check'",
-    "build": "xcodebuild -workspace sampleSwift/sampleSwift.xcodeproj/project.xcworkspace -scheme sampleSwift -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' build",
+    "build": "xcodebuild -workspace sampleSwift/sampleSwift.xcodeproj/project.xcworkspace -scheme sampleSwift -destination 'generic/platform=iOS Simulator' build",
     "build:check": "command -v xcodebuild >/dev/null 2>&1 && npm run build || echo 'Xcode not found, skipping build check'",
-    "test": "xcodebuild -workspace sampleSwift/sampleSwift.xcodeproj/project.xcworkspace -scheme sampleSwift -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' test",
+    "test": "xcodebuild -workspace sampleSwift/sampleSwift.xcodeproj/project.xcworkspace -scheme sampleSwift -destination \"id=$(scripts/pick-simulator.sh)\" test",
     "test:check": "command -v xcodebuild >/dev/null 2>&1 && npm run test || echo 'Xcode not found, skipping test check'",
     "prepare": "husky"
   },

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -29,6 +29,18 @@ cd sample-app-ios
 - **Usage**: `npm run version:sync`
 - See [CONTRIBUTING.md](../CONTRIBUTING.md#version-synchronization)
 
+### `pick-simulator.sh`
+- **Purpose**: Print the UDID of the best available iPhone simulator
+- **Usage**: `xcodebuild test -destination "id=$(scripts/pick-simulator.sh)"`
+- **Why**: device names are not stable. Everything here used to pin `iPhone 16`; when GitHub
+  rotated the `macos-latest` image to the iPhone 17 family, every run failed in ~2 minutes on
+  `Unable to find a device matching the provided destination specifier`. Addressing a
+  simulator by UDID avoids name *and* OS resolution.
+- Picks a plain `iPhone <n>` on the newest iOS runtime, falling back to any iPhone. The chosen
+  device goes to stderr (so CI logs record what ran); only the UDID goes to stdout.
+- Used by `npm run test` and `.github/workflows/ui-tests.yml`. Steps that only need to compile
+  use `-destination 'generic/platform=iOS Simulator'` instead and need no simulator at all.
+
 ## What's Being Tested
 
 ### 🔥 Critical Fix: NSDate Serialization (MSK-84)

--- a/scripts/pick-simulator.sh
+++ b/scripts/pick-simulator.sh
@@ -16,10 +16,15 @@
 # Usage:  xcodebuild test -destination "id=$(scripts/pick-simulator.sh)"
 set -euo pipefail
 
-if ! command -v xcrun >/dev/null 2>&1; then
-  echo "pick-simulator: xcrun not found (Xcode command line tools missing)" >&2
-  exit 1
-fi
+for tool in xcrun python3; do
+  if ! command -v "$tool" >/dev/null 2>&1; then
+    # Both ship with the Xcode command line tools, so in practice either both are present or
+    # neither is. Named explicitly anyway: a bare "python3: command not found" mid-pipeline
+    # gives no hint that it came from here.
+    echo "pick-simulator: $tool not found (install the Xcode command line tools: xcode-select --install)" >&2
+    exit 1
+  fi
+done
 
 udid=$(xcrun simctl list devices available --json | python3 -c "
 import json, re, sys

--- a/scripts/pick-simulator.sh
+++ b/scripts/pick-simulator.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+#
+# Print the UDID of the best available iPhone simulator.
+#
+# Exists because pinning a device name does not survive: GitHub rotated the macos-latest
+# simulator set to the iPhone 17 family and every run pinned to "iPhone 16" started failing
+# in ~2 minutes with "Unable to find a device matching the provided destination specifier".
+# Addressing a simulator by UDID sidesteps name *and* OS resolution entirely.
+#
+# Selection order, newest runtime first:
+#   1. a plain iPhone (e.g. "iPhone 17")      — preferred: smallest surprise for UI tests
+#   2. any other iPhone (Pro / Max / e / Air)  — fallback
+# Ties broken by highest model number. The chosen device is reported on stderr so CI logs
+# record what actually ran; only the UDID goes to stdout.
+#
+# Usage:  xcodebuild test -destination "id=$(scripts/pick-simulator.sh)"
+set -euo pipefail
+
+if ! command -v xcrun >/dev/null 2>&1; then
+  echo "pick-simulator: xcrun not found (Xcode command line tools missing)" >&2
+  exit 1
+fi
+
+udid=$(xcrun simctl list devices available --json | python3 -c "
+import json, re, sys
+
+data = json.load(sys.stdin)
+best = None
+
+def runtime_key(identifier):
+    # com.apple.CoreSimulator.SimRuntime.iOS-26-5 -> (26, 5)
+    tail = identifier.rsplit(\".\", 1)[-1]
+    return tuple(int(n) for n in re.findall(r\"\d+\", tail))
+
+for runtime, devices in data.get(\"devices\", {}).items():
+    if \"iOS\" not in runtime:
+        continue
+    for device in devices:
+        name = device.get(\"name\", \"\")
+        udid = device.get(\"udid\")
+        if not udid or not name.startswith(\"iPhone\"):
+            continue
+        model = re.search(r\"iPhone\s+(\d+)\", name)
+        rank = (
+            runtime_key(runtime),
+            1 if re.fullmatch(r\"iPhone\s+\d+\", name) else 0,
+            int(model.group(1)) if model else 0,
+        )
+        if best is None or rank > best[0]:
+            best = (rank, udid, name, runtime.rsplit(\".\", 1)[-1])
+
+if best is None:
+    sys.exit(\"pick-simulator: no available iPhone simulator found\")
+
+sys.stderr.write(\"pick-simulator: selected \" + best[2] + \" on \" + best[3] + \"\n\")
+print(best[1])
+")
+
+if [ -z "$udid" ]; then
+  echo "pick-simulator: could not resolve a simulator UDID" >&2
+  exit 1
+fi
+
+echo "$udid"


### PR DESCRIPTION
## Summary

**The nightly XCUITest workflow has never succeeded.** Every scheduled run since it started — 2026-08-11 through 2026-08-17 — has failed in ~2 minutes, which is nowhere near long enough for a ~30 minute suite:

```
xcodebuild: error: Unable to find a device matching the provided destination specifier:
    { platform:iOS Simulator, OS:latest, name:iPhone 16 }
```

GitHub rotated the `macos-latest` simulator set to the **iPhone 17 family**. The available iPhones are now `16e, 17, 17 Pro, 17 Pro Max, 17e, Air` — plain `iPhone 16` is gone. No OS was specified, so `xcodebuild` resolved `OS:latest`, where it definitely does not exist. Nothing was ever built, let alone tested.

## Two eras, worth not conflating

| When | What happened |
|---|---|
| **2026-06-04** (`pull_request`) | iPhone 16 existed; the suite **really ran** and failed on Test0 diagnostic assertions. Those are now gated behind `AXEPTIO_RUN_DIAGNOSTICS`, so that era is already resolved. |
| **2026-08-11 →** (`schedule`) | Destination resolution fails before anything builds. No signal at all. |

Only the second is a destination problem. Fixing it is what makes the suite capable of telling us anything.

## Fix: stop naming devices, because the name is the thing that rotates

**`scripts/pick-simulator.sh`** resolves the newest available iPhone and prints its UDID. Addressing a simulator by `id=` skips name *and* OS resolution entirely, so a future rotation cannot break it.

- Prefers a plain `iPhone <n>` on the newest iOS runtime (smallest surprise for UI tests), falls back to any iPhone.
- Exits non-zero with a clear message when there is no iPhone at all.
- Reports the chosen device on **stderr**, so CI logs record what actually ran; only the UDID goes to stdout.

**Per-site changes:**

- `ui-tests.yml` — resolves the UDID in its own step and **fails there** if the picker fails, rather than handing `xcodebuild` an empty destination and producing a much less obvious error downstream. Passed via `env:` rather than interpolated into the `run` block. The job name no longer advertises a device it may not use.
- `npm run test` — resolves a UDID the same way.
- `npm run build` and the `update-sdk-version` build step — now `generic/platform=iOS Simulator`. They only need to prove the code compiles and links, so they need no concrete device and cannot break on a rotation. This also speeds up the pre-commit hook, which runs `build:check`.

Note `update-sdk-version.yml` was pinned to `iPhone 16` by me during the 2.4.0 work — against a name that was already dying.

## Verification

```
$ scripts/pick-simulator.sh
pick-simulator: selected iPhone 17 on iOS-26-5     ← stderr
13B4B860-C623-4244-9FA8-DE8E2F0CC34C               ← stdout

$ xcodebuild build-for-testing -destination "id=$UDID"   → ** TEST BUILD SUCCEEDED **
$ xcodebuild build -destination 'generic/platform=iOS Simulator' → ** BUILD SUCCEEDED **
$ npm run build                                          → ** BUILD SUCCEEDED **
```

- [x] Deterministic across repeated runs
- [x] `bash -n` clean; no-iPhone path exits non-zero
- [x] All three workflow YAMLs parse; `package.json` valid
- [x] No device name left anywhere outside the picker's own documentation
- [ ] **Dispatch `ui-tests.yml` after merge** — this will be the first time the suite has ever produced real results, so expect genuine failures to surface. `Test5` is gated and will skip.

## Why this mattered more than it looked

With the nightly failing before it ran, there was never a signal to contradict the accept-button bug fixed in #48 — the suite had been pressing *"Close without accepting cookies"* while reporting acceptance. A red-but-never-executing nightly is worse than no nightly, because it looks like coverage.

Also untracks `.beads.gate.lock`, a local bd artifact that was neither ignored nor repo content.

Closes `sampleios-hsu`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
