### PR TITLE
fix(tests): route the rapid-tap test through the accept helper

### DIFF
--- a/sampleSwift/sampleSwiftUITests/Test1_WidgetDisplayTests.swift
+++ b/sampleSwift/sampleSwiftUITests/Test1_WidgetDisplayTests.swift
@@ -100,6 +100,9 @@ class Test1_WidgetDisplayTests: XCTestCase {
         XCTAssertTrue(webView.exists, "WebView should exist in the widget")
 
         // Check for consent buttons inside the WebView (at least one should exist)
+        // Broad on purpose: this asks "does the widget have any action button", so matching
+        // "Close without accepting cookies" is a correct answer. Do not reuse this predicate to
+        // *tap* accept — use helper.tapAcceptButton, which excludes negated phrasings.
         let hasAcceptButton = webView.buttons.containing(
             NSPredicate(format: "label CONTAINS[c] 'accept' OR label CONTAINS[c] 'tout accepter'")
         ).firstMatch.exists

--- a/sampleSwift/sampleSwiftUITests/Test2_ConsentFlowTests.swift
+++ b/sampleSwift/sampleSwiftUITests/Test2_ConsentFlowTests.swift
@@ -237,20 +237,25 @@ class Test2_ConsentFlowTests: XCTestCase {
 
         XCTAssertTrue(helper.isWidgetDisplayed(), "Widget should auto-display")
 
-        // When: User taps accept button multiple times rapidly
-        let webView = app.webViews.firstMatch
-        let acceptButton = webView.buttons.containing(NSPredicate(format: "label CONTAINS[c] 'accept'")).firstMatch
-
-        if acceptButton.exists {
-            acceptButton.tap()
-            acceptButton.tap() // Second tap (if widget hasn't dismissed yet)
-            sleep(5)
-
-            // Then: Widget should handle multiple taps gracefully (no crash)
-            // The test passing means the app didn't crash
-            print("✅ Test 5 Passed: Multiple consent actions handled gracefully")
-        } else {
-            throw XCTSkip("Accept button not found")
+        // When: User taps accept multiple times rapidly.
+        //
+        // Goes through the helper rather than matching the button here. This test used to run
+        // its own `label CONTAINS[c] 'accept'` lookup, which also matches "Close without
+        // accepting cookies" — so it was tapping the dismiss control while claiming to accept.
+        // The helper's predicate excludes negated phrasings; duplicating the lookup is what let
+        // the two drift apart.
+        guard helper.tapAcceptButton(timeout: 10.0) else {
+            throw XCTSkip("Accept button not found in the widget")
         }
+
+        // Second tap, if the widget has not dismissed yet. Expected to find nothing once it
+        // has, which is not a failure — the point is that a rapid double tap does not crash.
+        let secondTapLanded = helper.tapAcceptButton(timeout: 2.0)
+        print("  Second tap \(secondTapLanded ? "landed" : "found no button (widget already dismissed)")")
+        sleep(5)
+
+        // Then: the app is still alive and responsive after the rapid taps.
+        XCTAssertEqual(app.state, .runningForeground, "App should still be running after rapid consent taps")
+        print("✅ Test 5 Passed: Multiple consent actions handled gracefully")
     }
 }


### PR DESCRIPTION
## Summary

The first honest nightly run caught an incomplete fix of mine. `#48` corrected the accept predicate in `AxeptioIntegrationTestsHelper`, but I never grepped for duplicates of it — and `testMultipleConsentActions` had its own inline lookup:

```swift
webView.buttons.containing(NSPredicate(format: "label CONTAINS[c] 'accept'")).firstMatch
```

which also matches **"Close without accepting cookies"**. CI said so in as many words:

```
Failed to tap "Close without accepting cookies" Button ...
predicate 'label CONTAINS[c] "accept"'
```

So this test was still tapping the *dismiss* control while claiming to accept — the exact defect #48 was meant to remove, surviving in a second place because the lookup was duplicated rather than shared.

## Changes

- **`testMultipleConsentActions` now calls `helper.tapAcceptButton`**, whose predicate excludes negated phrasings (`without`, `sans`, `n'accepte`, `refuse`).
- **The rapid double tap now reports whether the second tap landed** rather than assuming it does, and asserts the app is still in the foreground afterwards. The old version had *no assertion at all* — its own comment conceded "the test passing means the app didn't crash", so it could not fail for the behaviour it was named after.
- **`Test1`'s `hasAcceptButton` predicate is deliberately left broad**, with a comment explaining why: it asks "does the widget have any action button", so matching the dismiss control is a *correct* answer there. Commented so it doesn't get copied into a tap, or tightened into uselessness.

## Verification

```
✅ Tapped accept button: 'Accept all cookies'
  Second tap found no button (widget already dismissed)
** TEST SUCCEEDED **
```

- [x] `swiftlint --strict` → 0 violations in 20 files
- [x] `TEST BUILD SUCCEEDED`
- [x] The previously-failing test passes and taps the correct control

## Context: the first real nightly result

Run `32010945682` — the first ever to reach the test phase — reported **28 total: 16 passed, 3 failed, 9 skipped**. Worth noting the raw log shows *17* failures for 8 unique tests, because `-test-iterations 3` counts every attempt; 5 of those 8 recovered on retry.

The three hard failures had three unrelated causes. This PR fixes one. The other two are filed rather than fixed blind, because both need a judgement call first:

- **`sampleios-66r` (P2)** — `Automation type mismatch: computed Other from legacy attributes vs WebView` on iOS 26.5. `webView.buttons` queries can fail outright, which no predicate change addresses and which undermines the suite's whole strategy of querying controls inside the consent webview. Needs a decision between retrying with relaunch, pinning an older runtime, or asking the widget team for natively-accessible controls.
- **`sampleios-tha` (P3)** — one `Failed to launch io.axeptio.sampleswift via Xcode`. Environmental; worth watching frequency before engineering around it.
- **`sampleios-qlf` (P3)** — the retry configuration itself. It converted a 5-test flaky tail into reported passes, and roughly triples wall clock on a bad run. Now that there's a real failure profile, worth deciding whether retries earn their place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
