### PR TITLE
ci(build): add a build and lint gate for pull requests

### DIFF
--- a/.github/workflows/build-and-lint.yml
+++ b/.github/workflows/build-and-lint.yml
@@ -1,0 +1,68 @@
+name: PR Checks
+
+# The PR gate for code. `swiftlint --strict` and an iOS Simulator build are the same two
+# checks .husky/pre-commit runs, which any --no-verify skips — this is the copy that
+# cannot be bypassed. The XCUITest suite deliberately stays out of it (nightly, ~30 min,
+# network-bound); see ui-tests.yml.
+#
+# Kept fully inline rather than calling axeptio/tech-scripts: this repo is public and
+# cannot access Axeptio's internal reusable workflows, so the `uses:` form reports no job
+# at all. Same reasoning as validate-pull-request-title.yml and ui-tests.yml.
+#
+# No `paths:` or `branches:` filter, on purpose. This job is a *required* status check on
+# develop: a filtered run that never reports leaves the PR pending forever rather than
+# failing it, so it has to run on every PR.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: build-and-lint-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-lint:
+    # This string is the required status-check context on develop. Renaming it silently
+    # breaks the merge gate — the old context stops being reported and every PR sits
+    # pending. Change it and the branch protection together, never one alone.
+    name: Build and lint
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+
+      # Ships with the current macos runner images, but installed rather than assumed: a
+      # required gate that skips itself when a tool is missing is worse than a slow one.
+      - name: Ensure SwiftLint
+        run: command -v swiftlint || brew install swiftlint
+
+      # Deliberately not `npm run lint:check` / `build:check`: those are
+      # `command -v <tool> || echo skipping` wrappers that exit 0 when the toolchain is
+      # absent. As a merge gate that is a check which can pass without checking anything.
+      # Uses the repo-root .swiftlint.yml.
+      - name: Lint
+        run: swiftlint --strict
+
+      - name: Resolve Swift packages
+        working-directory: sampleSwift
+        run: xcodebuild -resolvePackageDependencies -project sampleSwift.xcodeproj -scheme sampleSwift
+
+      # `generic/platform=iOS Simulator` builds without resolving a concrete device, so
+      # this needs no simulator and no scripts/pick-simulator.sh.
+      - name: Build
+        working-directory: sampleSwift
+        run: |
+          xcodebuild build \
+            -project sampleSwift.xcodeproj \
+            -scheme sampleSwift \
+            -destination 'generic/platform=iOS Simulator'

--- a/.github/workflows/build-and-lint.yml
+++ b/.github/workflows/build-and-lint.yml
@@ -53,6 +53,11 @@ jobs:
       - name: Lint
         run: swiftlint --strict
 
+      # `-project`, matching ui-tests.yml and update-sdk-version.yml. There is no
+      # separate .xcworkspace in this repo: Package.resolved lives under the project's
+      # *implicit* workspace (sampleSwift.xcodeproj/project.xcworkspace/xcshareddata/),
+      # so -project and -workspace resolve the same container and the same pins. Both
+      # were run against this commit and both build. Not worth churning.
       - name: Resolve Swift packages
         working-directory: sampleSwift
         run: xcodebuild -resolvePackageDependencies -project sampleSwift.xcodeproj -scheme sampleSwift

--- a/.github/workflows/update-sdk-version.yml
+++ b/.github/workflows/update-sdk-version.yml
@@ -98,8 +98,10 @@ jobs:
       uses: peter-evans/create-pull-request@v7
       with:
         # Note: a PR opened with GITHUB_TOKEN does not trigger downstream workflow
-        # runs, so checks on the generated PR must be kicked off manually (e.g. by
-        # pushing an empty commit) or by swapping in a PAT / GitHub App token.
+        # runs. Since develop requires "Build and lint" and "Normalize and validate
+        # PR title" to merge, the generated PR is not merely missing its checks — it
+        # cannot be merged until they report. Push an empty commit to the generated
+        # branch to trigger them, or swap in a PAT / GitHub App token.
         token: ${{ secrets.GITHUB_TOKEN }}
         commit-message: |
           feat: update Axeptio iOS SDK to v${{ github.event.inputs.sdk_version }}

--- a/.github/workflows/update-sdk-version.yml
+++ b/.github/workflows/update-sdk-version.yml
@@ -98,7 +98,7 @@ jobs:
       uses: peter-evans/create-pull-request@v7
       with:
         # Note: a PR opened with GITHUB_TOKEN does not trigger downstream workflow
-        # runs. Since develop requires "Build and lint" and "Normalize and validate
+        # runs. Once develop requires "Build and lint" and "Normalize and validate
         # PR title" to merge, the generated PR is not merely missing its checks — it
         # cannot be merged until they report. Push an empty commit to the generated
         # branch to trigger them, or swap in a PAT / GitHub App token.


### PR DESCRIPTION
## Why

An org compliance scan fails this repo on:

> ❌ Expecting at least one Required Status Check to be enforced on the default branch (must pass before merge, to ensure SDLC gates) — via classic protection or a `required_status_checks` ruleset

`develop` has classic protection (1 approval, dismiss-stale, signed commits) but **zero** required status checks.

The task started as "port the PR title check from `tech-scripts`". It turns out that check is **already here** — `validate-pull-request-title.yml`, inlined at `948935e`, green on #47–#51. It was deliberately not written as `uses: axeptio/tech-scripts/...`, because `tech-scripts` is `internal` and this repo is public, so that form reports no job at all. (`sample-app-android` has exactly that bug today: it requires a context its workflow can never produce.) Nothing needs porting; only enforcement was missing.

But requiring only the title check would clear the scan while leaving the gate it names unbuilt. `Normalize and validate PR title` is the **only** check that runs on PRs here — CodeQL default setup is `not-configured`, and the XCUITest suite is nightly-only by design. There was no code gate to require.

## What this does

Adds `.github/workflows/build-and-lint.yml` — job **`Build and lint`**, `swiftlint --strict` then an iOS Simulator build. These are the same two checks `.husky/pre-commit` already runs, which any `--no-verify` skips; this is the copy that cannot be bypassed.

Deliberate choices, each with a failure mode behind it:

- **Calls `swiftlint` / `xcodebuild` directly, not `npm run lint:check` / `build:check`.** Those wrappers are `command -v <tool> ... || echo 'skipping'` and exit 0 when the toolchain is absent. As a merge gate, that is a check that can pass without checking anything.
- **No `paths:` or `branches:` filter.** A required check that doesn't run leaves the PR *pending forever* rather than failing it, so it must run on every PR.
- **Kept inline**, same reasoning as `ui-tests.yml` and the title workflow.
- The job `name:` is the status-check context. Renaming it silently breaks the merge gate, so the workflow says so where someone would edit it.

Also sharpens the `GITHUB_TOKEN` note in `update-sdk-version.yml`: PRs it opens don't trigger workflow runs, so once these checks are required its generated PRs become unmergeable rather than merely unchecked.

## Follow-up (after merge, not in this PR)

Add both contexts to `develop`'s classic protection — `Normalize and validate PR title` and `Build and lint` — read back verbatim from a real PR's check-runs rather than guessed. That is what actually clears the scan finding.

## Verification

- `swiftlint --strict` → 0 violations, 0 serious in 20 files
- `xcodebuild build -project sampleSwift.xcodeproj -scheme sampleSwift -destination 'generic/platform=iOS Simulator'` → **BUILD SUCCEEDED** (the exact invocation the workflow runs)
- Both re-ran via the pre-commit hook on commit
- YAML parses; job name confirmed as `Build and lint`

Refs: `sampleios-eek`

🤖 Generated with [Claude Code](https://claude.com/claude-code)