### PR TITLE
test: verify the required build and lint check blocks merge

### DIFF
--- a/sampleSwift/sampleSwift/LintCanary.swift
+++ b/sampleSwift/sampleSwift/LintCanary.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+// Deliberate SwiftLint violations, to prove the required check fails a bad PR.
+struct LintCanary {   
+    static func canary(_ value: Any) -> String {
+        return value as! String
+    }
+}


### PR DESCRIPTION
Throwaway PR. Contains a deliberate SwiftLint violation (`force_cast` + trailing whitespace) to confirm that `Build and lint` fails and that the failure actually blocks merge on `develop`.

Will be closed and the branch deleted once observed. Do not merge.